### PR TITLE
fix(add-on): Fix ActivityStreams option defaulting, main.js exports

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -16,9 +16,14 @@ XPCOMUtils.defineLazyGetter(this, "EventEmitter", function () {
   return EventEmitter;
 });
 
-let ActivityStreams = function (options = {pageURL: data.url("content/activity-streams.html")}) {
+const DEFAULT_OPTIONS = {
+  pageURL: data.url("content/activity-streams.html")
+};
+
+function ActivityStreams(options = {}) {
   console.debug(`ActivityStreams.init`);
-  this.options = options;
+  this.options = Object.assign({}, DEFAULT_OPTIONS, options);
+
   EventEmitter.decorate(this);
 
   this._setupPageMod();
@@ -100,7 +105,6 @@ ActivityStreams.prototype = {
       contentScriptWhen: "start",
       attachTo: "top",
       onAttach: worker => {
-
         // add the worker to a set to enable broadcasting
         if (!this.workers.has(worker)) {
           this.workers.add(worker);

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,10 +8,11 @@ if (!storage.clientUUID) {
   storage.clientUUID = uuid();
 }
 
-exports = {
+Object.assign(exports, {
   app: null,
 
   main(options) {
+
     // options.loadReason can be install/enable/startup/upgrade/downgrade
     PlacesProvider.links.init();
     exports.app = new ActivityStreams(options);
@@ -23,4 +24,4 @@ exports = {
     }
     PlacesProvider.links.uninit();
   }
-};
+});


### PR DESCRIPTION
I'm not sure why, but for some reason the `main` function never gets run when you replace `exports` completely; 

Also fixes defaulting of individual options for `ActivtiyStreams`