### PR TITLE
chore(lint): Extend the ESLint recommended rules

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 data/content/
 logs/
-node_modules/
 firefox/

--- a/.eslintrc
+++ b/.eslintrc
@@ -4,33 +4,38 @@
     "mozilla",
     "react"
   ],
+  "extends": [
+    "eslint:recommended"
+  ],
   "rules": {
     "mozilla/components-imports": 1,
     "mozilla/import-globals-from": 1,
     "mozilla/this-top-level-scope": 1,
-    "no-unused-vars": 2,
-    "semi": [2, "always"],
-    "no-undef": 2,
-    "object-curly-spacing": [2, "never"],
-    "computed-property-spacing": [2, "never"],
-    "array-bracket-spacing": [2, "never"],
-    "space-before-function-paren": [2, {"anonymous": "never", "named": "never"}],
+
     "react/jsx-uses-react": 1,
+
+    "array-bracket-spacing": [2, "never"],
+    "comma-dangle": 0,
+    "computed-property-spacing": [2, "never"],
+    "no-console": 1,
     "no-trailing-spaces": [2, {"skipBlankLines": false}],
+    "no-undef": 2,
+    "no-unused-vars": 2,
+    "object-curly-spacing": [2, "never"],
+    "semi": [2, "always"],
+    "space-before-function-paren": [2, {"anonymous": "never", "named": "never"}]
   },
   "ecmaFeatures": {
     "jsx": true
   },
   "env": {
-    "es6": true,
-    "node": true,
     "browser": true,
+    "es6": true,
     "mocha": true,
+    "node": true,
   },
   "globals": {
-    "require": true,
     "StopIteration": true,
-    "exports": true,
     "__CONFIG__": true
   }
 }

--- a/content-src/lib/ActionManager.js
+++ b/content-src/lib/ActionManager.js
@@ -58,7 +58,7 @@ class ActionManager {
     }
     return action;
   }
-};
+}
 
 // This is an extremely bare-bones action types
 // that can be used if you just want a plain action,

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -29,7 +29,7 @@ function ActivityStreams(options = {}) {
   this._setupPageMod();
   this._setupListeners();
   NewTabURL.override(this.options.pageURL);
-};
+}
 
 ActivityStreams.prototype = {
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -13,7 +13,7 @@ let config = yaml.load("config.default.yml");
 try {
   // Load user config if it exists
   config = Object.assign({}, config, yaml.load("config.yml"));
-} catch (e) {}
+} catch (e) {} // eslint-disable-line no-empty
 
 module.exports = {
   entry: srcPath,


### PR DESCRIPTION
Current output is:
```sh
➜  activity-streams git:(eslint-tweaks) npm run test:lint

> activity-streams@0.0.1 test:lint /Users/pdehaan/dev/github/activity-streams
> eslint . && jscs .


/Users/pdehaan/dev/github/activity-streams/lib/ActivityStreams.js
   24:3   warning  Unexpected console statement  no-console
  114:13  warning  Unexpected console statement  no-console
  119:13  warning  Unexpected console statement  no-console
  126:9   warning  Unexpected console statement  no-console
  135:5   warning  Unexpected console statement  no-console

/Users/pdehaan/dev/github/activity-streams/test/lib/utils.js
  24:7  warning  Unexpected console statement  no-console

✖ 6 problems (0 errors, 6 warnings)

➜  activity-streams git:(eslint-tweaks) echo $?
0
```

Only 6 warnings (so task still passes), but makes the `console.log()` usage a bit more obvious. We can obviously mute those by changing to `no-console: 0`.