### PR TITLE
chore(react): Convert React.createClass to extends React.Component

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,10 @@
-node_modules
-npm-debug.log
-.DS_Store
 *.sw[po]
 *.xpi
-logs/
-dist/
+.DS_Store
+config.yml
 data/content/
+dist/
 firefox/
+logs/
+node_modules
+npm-debug.log

--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -1,6 +1,14 @@
 const React = require("react");
 
-const ActivityFeedItem = React.createClass({
+class ActivityFeedItem extends React.Component {
+  static get propTypes() {
+    return {
+      image: React.PropTypes.string, // TODO: Have fallback for this, change to icon
+      title: React.PropTypes.string.isRequired,
+      url: React.PropTypes.string.isRequired
+    };
+  }
+
   render() {
     const site = this.props;
     return (<li className="feed-item">
@@ -17,26 +25,22 @@ const ActivityFeedItem = React.createClass({
       </div>
     </li>);
   }
-});
+}
 
-ActivityFeedItem.propTypes = {
-  url: React.PropTypes.string.isRequired,
-  image: React.PropTypes.string, // TODO: Have fallback for this, change to icon
-  title: React.PropTypes.string.isRequired
-};
+class ActivityFeed extends React.Component {
+  static get propTypes() {
+    return {
+      sites: React.PropTypes.array.isRequired
+    };
+  }
 
-const ActivityFeed = React.createClass({
   render() {
-    const {props} = this;
+    const props = this.props;
     return (<ul className="activity-feed">
       {props.sites.map(site => <ActivityFeedItem key={site.url} {...site} />)}
     </ul>);
   }
-});
-
-ActivityFeed.propTypes = {
-  sites: React.PropTypes.array.isRequired
-};
+}
 
 module.exports = ActivityFeed;
 module.exports.ActivityFeedItem = ActivityFeedItem;

--- a/content-src/components/Base/Base.js
+++ b/content-src/components/Base/Base.js
@@ -4,14 +4,15 @@ const {actions} = require("actions/action-manager");
 
 const Header = require("components/Header/Header");
 
-const Base = React.createClass({
+class Base extends React.Component {
   componentDidMount() {
     // This should work!
     this.props.dispatch(actions.RequestTopFrecent());
 
     // This should fail, since nothing is implemented on the Firefox side
     this.props.dispatch(actions.RequestBookmarks());
-  },
+  }
+
   render() {
     const props = this.props;
     return (<div id="base">
@@ -24,7 +25,7 @@ const Base = React.createClass({
       {props.children}
     </div>);
   }
-});
+};
 
 function select(state) {
   return state;

--- a/content-src/components/Header/Header.js
+++ b/content-src/components/Header/Header.js
@@ -1,10 +1,22 @@
 const React = require("react");
 const {Link} = require("react-router");
 
-const Header = React.createClass({
-  getInitialState() {
-    return {showDropdown: false};
-  },
+class Header extends React.Component {
+  constructor(props) {
+    super(props);
+
+    this.state = {
+      showDropdown: false
+    };
+  }
+
+  static get propTypes() {
+    return {
+      userImage: React.PropTypes.string,
+      userName: React.PropTypes.string
+    };
+  }
+
   render() {
     const props = this.props;
     return (<header className="head">
@@ -25,11 +37,6 @@ const Header = React.createClass({
       </section>
     </header>);
   }
-});
-
-Header.propTypes = {
-  userName: React.PropTypes.string,
-  userImage: React.PropTypes.string,
-};
+}
 
 module.exports = Header;

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -4,7 +4,7 @@ const {connect} = require("react-redux");
 const TopSites = require("components/TopSites/TopSites");
 const ActivityFeed = require("components/ActivityFeed/ActivityFeed");
 
-const NewTabPage = React.createClass({
+class NewTabPage extends React.Component {
   render() {
     const props = this.props;
     return (<main className="new-tab">
@@ -22,7 +22,7 @@ const NewTabPage = React.createClass({
       </div>
     </main>);
   }
-});
+}
 
 function select(state) {
   return state;

--- a/content-src/components/Routes/Routes.js
+++ b/content-src/components/Routes/Routes.js
@@ -2,17 +2,21 @@ const React = require("react");
 const {Router, Route, IndexRoute} = require("react-router");
 const {createHashHistory} = require("history");
 
+const Base = require("components/Base/Base");
+const NewTabPage = require("components/NewTabPage/NewTabPage");
+const TimelinePage = require("components/TimelinePage/TimelinePage");
+
 const history = createHashHistory({queryKey: false});
 
-const Routes = React.createClass({
+class Routes extends React.Component {
   render() {
     return (<Router history={history}>
-      <Route path="/" component={require("components/Base/Base")}>
-        <IndexRoute title="Home" component={require("components/NewTabPage/NewTabPage")} />
-        <Route title="Timeline" path="timeline" component={require("components/TimelinePage/TimelinePage")} />
+      <Route path="/" component={Base}>
+        <IndexRoute title="Home" component={NewTabPage} />
+        <Route title="Timeline" path="timeline" component={TimelinePage} />
       </Route>
     </Router>);
   }
-});
+}
 
 module.exports = Routes;

--- a/content-src/components/TimelinePage/TimelinePage.js
+++ b/content-src/components/TimelinePage/TimelinePage.js
@@ -3,15 +3,18 @@ const {connect} = require("react-redux");
 
 const ActivityFeed = require("components/ActivityFeed/ActivityFeed");
 
-const TimelinePage = React.createClass({
+class TimelinePage extends React.Component {
   render() {
     const props = this.props;
-    const navItems = [{title: "All", active: true}, {title: "Bookmarks"}];
+    const navItems = [
+      {title: "All", active: true},
+      {title: "Bookmarks"}
+    ];
     return (<main className="timeline">
       <nav className="sidebar">
         <ul>
-          {navItems.map(item => {
-            return (<li key={item.title}>
+          {navItems.map((item, idx) => {
+            return (<li key={idx}>
               <a className={item.active ? "active" : ""}>{item.title}</a>
             </li>);
           })}
@@ -25,7 +28,7 @@ const TimelinePage = React.createClass({
       </section>
     </main>);
   }
-});
+}
 
 function select(state) {
   return state;

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -1,6 +1,21 @@
 const React = require("react");
 
-const TopSites = React.createClass({
+class TopSites extends React.Component {
+  static get propTypes() {
+    return {
+      sites: React.PropTypes.arrayOf(
+        React.PropTypes.shape({
+          title: React.PropTypes.string.isRequired,
+          image: React.PropTypes.string,
+          leadImage: React.PropTypes.string,
+          url: React.PropTypes.string.isRequired,
+          type: React.PropTypes.string,
+          description: React.PropTypes.string
+        })
+      ).isRequired
+    };
+  }
+
   render() {
     const props = this.props;
     return (<section className="top-sites">
@@ -18,19 +33,6 @@ const TopSites = React.createClass({
       </div>
     </section>);
   }
-});
-
-TopSites.propTypes = {
-  sites: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      title: React.PropTypes.string.isRequired,
-      image: React.PropTypes.string,
-      leadImage: React.PropTypes.string,
-      url: React.PropTypes.string.isRequired,
-      type: React.PropTypes.string,
-      description: React.PropTypes.string
-    })
-  ).isRequired
-};
+}
 
 module.exports = TopSites;

--- a/content-src/main.js
+++ b/content-src/main.js
@@ -7,12 +7,12 @@ const store = require("./store");
 
 require("lib/shim")();
 
-const Root = React.createClass({
+class Root extends React.Component {
   render() {
     return (<Provider store={store}>
       <Routes />
     </Provider>);
   }
-});
+}
 
 ReactDOM.render(<Root />, document.getElementById("root"));


### PR DESCRIPTION
Following guidelines from http://www.newmediacampaigns.com/blog/refactoring-react-components-to-es6-classes:

> Starting with React 0.13, defining components using ES6 classes is encouraged.

I haven't investigated yet to see if some/most of these could be converted to a [Stateless Function](https://facebook.github.io/react/docs/reusable-components.html#stateless-functions).

Also attempted to replace all the `require()` and `module.exports` with the more ES2015-esque `import` and `export`, but oh boy that went over poorly locally.