### PR TITLE
chore(travis): Temporarily disable jpm tests due to #92

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,6 @@
     "package": "jpm xpi && mv @activity-streams-$npm_package_version.xpi dist/activity-streams-$npm_package_version.xpi",
     "travis": "npm-run-all travis:*",
     "travis:eslint": "npm run test:lint",
-    "travis:jpm": "jpm test -b $JPM_FIREFOX_BINARY -v",
     "travis:karma": "karma start --reporters mocha,coverage,coveralls",
     "precommit": "npm run test:lint && npm run yamscripts",
     "help": "yamscripts help",

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -43,7 +43,8 @@ scripts:
   # This is for ci
   travis:
     eslint: =>test:lint
-    jpm: jpm test -b $JPM_FIREFOX_BINARY -v
+    # TODO: Disabled due to https://github.com/mozilla/activity-streams/issues/93
+    # jpm: jpm test -b $JPM_FIREFOX_BINARY -v
     karma: karma start --reporters mocha,coverage,coveralls
 
   # This is just to make sure we don't make commits with failing tests


### PR DESCRIPTION
I'd like to disable our `jpm` tests temporarily and rely on running them locally until we resolve the race condition issues/travis issues, so we don't have unrelated failures on other PRs in the mean time.

Are you ok with this @rlr @oyiptong @emtwo @mzhilyaev?
