### PR TITLE
fix(content): Only show sites in Spotlight if it has atleast one image

### DIFF
--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -6,10 +6,9 @@ const SpotlightItem = React.createClass({
   render() {
     const site = this.props;
     const imageUrl = site.images[0].url;
-    const iconUrl = site.favicon_url;
+    const description = site.description;
     return (<li className="spotlight-item">
       <div className="spotlight-image" style={{backgroundImage: `url(${imageUrl})`}} ref="image">
-        <div className="spotlight-icon" style={{backgroundImage: `url(${iconUrl})`}} ref="icon" />
         <SiteIcon className="spotlight-icon" site={site} ref="icon" height={32} width={32} />
       </div>
       <div className="spotlight-details">
@@ -17,7 +16,7 @@ const SpotlightItem = React.createClass({
           <h4 className="spotlight-title">
             <a href={site.url} ref="link">{site.title}</a>
           </h4>
-          <p className="spotlight-description" ref="description">{site.description}</p>
+          <p className="spotlight-description" ref="description">{description}</p>
           <div className="spotlight-type">Last opened on iPhone</div>
         </div>
       </div>
@@ -27,11 +26,15 @@ const SpotlightItem = React.createClass({
 
 SpotlightItem.propTypes = {
   url: React.PropTypes.string.isRequired,
-  images: React.PropTypes.array,
+  images: React.PropTypes.arrayOf(
+    React.PropTypes.shape({
+      url: React.PropTypes.string.isRequired
+    }).isRequired
+  ).isRequired,
   favicon_url: React.PropTypes.string,
   icons: React.PropTypes.array,
   title: React.PropTypes.string,
-  description: React.PropTypes.string.isRequired,
+  description: React.PropTypes.string
 };
 
 const Spotlight = React.createClass({
@@ -39,7 +42,12 @@ const Spotlight = React.createClass({
     return {length: DEFAULT_LENGTH};
   },
   render() {
-    const sites = this.props.sites.slice(0, this.props.length);
+    const sites = this.props.sites
+      .filter(site => {
+        // Don't use sites that don't have an image
+        return !!(site.images && site.images[0] && site.images[0].url);
+      })
+      .slice(0, this.props.length);
     return (<section className="spotlight">
       <h3 className="section-title">Spotlight</h3>
       <ul>

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -8,16 +8,11 @@ const SiteIcon = require("components/SiteIcon/SiteIcon");
 const fakeSpotlightItems = require("lib/fake-data").History.rows;
 
 describe("Spotlight", function() {
-  let node;
   let instance;
   let el;
   beforeEach(() => {
-    node = document.createElement("div");
-    instance = ReactDOM.render(<Spotlight sites={fakeSpotlightItems} />, node);
+    instance = TestUtils.renderIntoDocument(<Spotlight sites={fakeSpotlightItems} />);
     el = ReactDOM.findDOMNode(instance);
-  });
-  afterEach(() => {
-    ReactDOM.unmountComponentAtNode(node);
   });
 
   describe("valid sites", () => {
@@ -27,6 +22,18 @@ describe("Spotlight", function() {
     it("should render a SpotlightItem for each item", () => {
       const children = TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem);
       assert.equal(children.length, 3);
+    });
+    it("should skip sites that do not have an images prop", () => {
+      const sites = [
+        {title: "Hello world", url: "bar.com", description: "123"},
+        {title: "Foo", url: "bar1.com", images: [{url: "foo.jpg"}]},
+        {title: "Bar", url: "bar2.com", images: [{url: "bar.jpg"}]},
+        {title: "Baz", url: "bar3.com", images: []},
+        {title: "Baz", url: "bar4.com", images: [{}]},
+      ];
+      const testInstance = TestUtils.renderIntoDocument(<Spotlight sites={sites} length={5} />);
+      const children = TestUtils.scryRenderedComponentsWithType(testInstance, SpotlightItem);
+      assert.equal(children.length, 2);
     });
   });
 });


### PR DESCRIPTION
This should fix an existing bug where Spotlights don't show up at all if the `images` prop is missing

Fixes #121