### PR TITLE
refactor(ActivityFeed): Remove leading http(s)://(www.) from displayed URLs

### DIFF
--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -7,12 +7,13 @@ const ActivityFeedItem = React.createClass({
   render() {
     const site = this.props;
     const title = site.bookmarkTitle || site.title;
+    const prettyUrl = site.url.replace(/^https?:\/\/(www\.)?/i, "");
     return (<li className="feed-item">
       <SiteIcon ref="icon" className="feed-icon" site={site} width={ICON_SIZE} height={ICON_SIZE} />
       <div className="feed-details">
         <div className="feed-description">
           <h4 className="feed-title" ref="title">{title}</h4>
-          <a className="feed-link" href={site.url} ref="link">{site.url}</a>
+          <a className="feed-link" href={site.url} ref="link">{prettyUrl}</a>
         </div>
         <div className="feed-stats">
           <div>1:26pm</div>

--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -1,19 +1,20 @@
 const React = require("react");
-const DEFAULT_LENGTH = 3;
 const SiteIcon = require("components/SiteIcon/SiteIcon");
+const {prettyUrl} = require("lib/utils");
+
+const DEFAULT_LENGTH = 3;
 const ICON_SIZE = 40;
 
 const ActivityFeedItem = React.createClass({
   render() {
     const site = this.props;
     const title = site.bookmarkTitle || site.title;
-    const prettyUrl = site.url.replace(/^https?:\/\/(www\.)?/i, "");
     return (<li className="feed-item">
       <SiteIcon ref="icon" className="feed-icon" site={site} width={ICON_SIZE} height={ICON_SIZE} />
       <div className="feed-details">
         <div className="feed-description">
           <h4 className="feed-title" ref="title">{title}</h4>
-          <a className="feed-link" href={site.url} ref="link">{prettyUrl}</a>
+          <a className="feed-link" href={site.url} ref="link">{prettyUrl(site.url)}</a>
         </div>
         <div className="feed-stats">
           <div>1:26pm</div>

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -47,6 +47,7 @@
     max-height: $spotlight-title-max-height;
     overflow: hidden;
   }
+
   &:hover .spotlight-title {
     color: $link-blue;
   }

--- a/content-src/lib/utils.js
+++ b/content-src/lib/utils.js
@@ -6,5 +6,8 @@ module.exports = {
   getBlackOrWhite(r, g, b) {
     const yiq = ((r * 299) + (g * 587) + (b * 114)) / 1000;
     return (yiq >= 128) ? "black" : "white";
+  },
+  prettyUrl(url) {
+    return url.replace(/^https?:\/\/(www\.)?/i, "");
   }
 };

--- a/content-test/components/ActivityFeed.test.js
+++ b/content-test/components/ActivityFeed.test.js
@@ -5,6 +5,7 @@ const SiteIcon = require("components/SiteIcon/SiteIcon");
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
+const {prettyUrl} = require("lib/utils");
 
 const fakeSites = require("test/test-utils").mockData.Bookmarks.rows;
 
@@ -55,7 +56,7 @@ describe("ActivityFeedItem", function() {
     });
     it("should render the url link", () => {
       const linkEl = instance.refs.link;
-      assert.equal(linkEl.innerHTML, fakeSite.url);
+      assert.equal(linkEl.innerHTML, prettyUrl(fakeSite.url));
       assert.include(linkEl.href, fakeSite.url);
     });
   });

--- a/content-test/lib/utils.test.js
+++ b/content-test/lib/utils.test.js
@@ -18,3 +18,19 @@ describe("getBlackOrWhite", () => {
     assert.equal(utils.getBlackOrWhite(40, 44, 52), "white");
   });
 });
+
+describe("prettyUrl()", () => {
+  it("should strip out leading http:// or https://", () => {
+    assert.equal(utils.prettyUrl("http://mozilla.org/"), "mozilla.org/");
+    assert.equal(utils.prettyUrl("https://mozilla.org/"), "mozilla.org/");
+  });
+
+  it("should strip out leading 'www.' subdomains", () => {
+    assert.equal(utils.prettyUrl("https://www.mozilla.org/"), "mozilla.org/");
+  });
+
+  it("should ignore non http[s] protocols", () => {
+    let url = "gopher://github.com/mozilla/";
+    assert.equal(utils.prettyUrl(url), url);
+  });
+});


### PR DESCRIPTION
Removes leading "http://" and "https://" (and "www.", if it exists) from the displayed URLs in the ActivityFeed, if they exist. This only removes them from the displayed URL, not the link, so this is purely cosmetic.

Fixes #134 