### PR TITLE
fix(content): Make sure components do not throw if some data is missing

### DIFF
--- a/content-src/components/Header/Header.js
+++ b/content-src/components/Header/Header.js
@@ -7,16 +7,17 @@ const Header = React.createClass({
   },
   render() {
     const props = this.props;
+    const currentRoute = props.currentRoute || {};
     return (<header className="head">
       <section className="nav" onClick={() => this.setState({showDropdown: !this.state.showDropdown})}>
         <h1>
-          <span hidden={!props.currentRoute.icon} className={`icon fa ${props.currentRoute.icon}`} />
-          <span>{props.currentRoute.title}</span>
+          <span hidden={!currentRoute.icon} className={`icon fa ${currentRoute.icon}`} />
+          <span>{currentRoute.title}</span>
           <span className="arrow fa fa-chevron-down" />
         </h1>
         <ul className="nav-picker" hidden={!this.state.showDropdown}>
-          <li hidden={props.currentRoute.path === "/"}><Link to="/">Home</Link></li>
-          <li hidden={props.currentRoute.path === "/timeline"}><Link to="/timeline">Activity Stream</Link></li>
+          <li hidden={currentRoute.path === "/"}><Link to="/">Home</Link></li>
+          <li hidden={currentRoute.path === "/timeline"}><Link to="/timeline">Activity Stream</Link></li>
         </ul>
       </section>
       <section className="spacer" />

--- a/content-src/components/SiteIcon/SiteIcon.js
+++ b/content-src/components/SiteIcon/SiteIcon.js
@@ -50,7 +50,7 @@ function getFallbackColors(favicon_colors) {
 const SiteIconFallback = React.createClass({
   render() {
     const {favicon_colors, title, provider_name, provider_display} = this.props;
-    const letter = (provider_name || provider_display || title)[0];
+    const letter = (provider_name || provider_display || title || "")[0];
     const style = getFallbackColors(favicon_colors);
     return (<div className="site-icon-fallback" ref="fallback"
       style={style}>
@@ -71,6 +71,7 @@ SiteIconFallback.propTypes = {
 const SiteIcon = React.createClass({
   getDefaultProps() {
     return {
+      site: {},
       height: 100,
       width: 100
     };

--- a/content-src/lib/embedly-middleware.js
+++ b/content-src/lib/embedly-middleware.js
@@ -20,10 +20,6 @@ module.exports = () => next => action => {
   if (action.error) {
     return next(action);
   }
-  // We can't fetch extra data if the embedly server is not running
-  if (!isDevServerRunning) {
-    return next(action);
-  }
   if (actionsToSupplement.has(action.type)) {
     if (!action.data.length) {
       return next(action);
@@ -31,6 +27,12 @@ module.exports = () => next => action => {
     const sites = action.data.filter(site => {
       return !(!site.url || /^place:/.test(site.url));
     });
+
+    // We can't fetch extra data if the embedly server is not running
+    if (!isDevServerRunning) {
+      return next(action);
+    }
+
     fetch("http://localhost:1467/extract?" + buildQuery(sites))
       .then(response => response.json())
       .then(json => {

--- a/content-src/lib/utils.js
+++ b/content-src/lib/utils.js
@@ -8,6 +8,9 @@ module.exports = {
     return (yiq >= 128) ? "black" : "white";
   },
   prettyUrl(url) {
+    if (!url) {
+      return "";
+    }
     return url.replace(/^https?:\/\/(www\.)?/i, "");
   }
 };

--- a/content-test/components/ActivityFeed.test.js
+++ b/content-test/components/ActivityFeed.test.js
@@ -37,6 +37,12 @@ describe("ActivityFeedItem", function() {
     el = ReactDOM.findDOMNode(instance);
   });
 
+  it("should not throw if missing props", () => {
+    assert.doesNotThrow(() => {
+      TestUtils.renderIntoDocument(<ActivityFeedItem />);
+    });
+  });
+
   describe("valid sites", () => {
     it("should create the element", () => {
       assert.ok(el);

--- a/content-test/components/Header.test.js
+++ b/content-test/components/Header.test.js
@@ -2,8 +2,9 @@
 
 const assert = require("chai").assert;
 const Header = require("components/Header/Header");
-const React = require("react"); // eslint-disable-line no-unused-vars
+const React = require("react");
 const ReactDOM = require("react-dom");
+
 const fakeProps = {
   currentRoute: {
     title: "Home",

--- a/content-test/components/SiteIcon.test.js
+++ b/content-test/components/SiteIcon.test.js
@@ -31,6 +31,12 @@ describe("SiteIcon", () => {
   beforeEach(() => setup());
 
   describe("SiteIcon", () => {
+    it("should not throw if missing props", () => {
+      assert.doesNotThrow(() => {
+        TestUtils.renderIntoDocument(<SiteIcon />);
+      });
+    });
+
     it("should create a SiteIcon instance", () => {
       assert.instanceOf(instance, SiteIcon);
     });

--- a/content-test/components/TopSites.test.js
+++ b/content-test/components/TopSites.test.js
@@ -25,6 +25,12 @@ describe("TopSites", () => {
     ReactDOM.unmountComponentAtNode(node);
   });
 
+  it("should not throw if missing props", () => {
+    assert.doesNotThrow(() => {
+      TestUtils.renderIntoDocument(<TopSites sites={[{}]} />);
+    });
+  });
+
   describe("valid sites", () => {
     it("should create TopSites", () => {
       assert.instanceOf(topSites, TopSites);

--- a/content-test/lib/utils.test.js
+++ b/content-test/lib/utils.test.js
@@ -20,6 +20,12 @@ describe("getBlackOrWhite", () => {
 });
 
 describe("prettyUrl()", () => {
+
+  it("should return a blank string if url is falsey", () => {
+    assert.equal(utils.prettyUrl(), "");
+    assert.equal(utils.prettyUrl(null), "");
+  });
+
   it("should strip out leading http:// or https://", () => {
     assert.equal(utils.prettyUrl("http://mozilla.org/"), "mozilla.org/");
     assert.equal(utils.prettyUrl("https://mozilla.org/"), "mozilla.org/");

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "test": "npm-run-all test:*",
     "test:lint": "eslint . && jscs . && sass-lint -v -q",
     "test:jpm": "jpm test -b beta",
-    "test:karma": "karma start",
+    "test:karma": "karma start --browsers FirefoxNightly",
     "tdd": "karma start --no-single-run",
     "package": "jpm xpi && mv @activity-streams-$npm_package_version.xpi dist/activity-streams-$npm_package_version.xpi",
     "travis": "npm-run-all travis:*",

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -41,7 +41,7 @@ scripts:
     # test:jpm: Run jpm tests
     jpm: jpm test -b beta
     # test:karma: Run content tests only
-    karma: karma start
+    karma: karma start --browsers FirefoxNightly
 
 # tdd: Run content tests continuously
   tdd: karma start --no-single-run


### PR DESCRIPTION
The reasoning behind this is that sometimes we get weirdly formatted history items, which ideally we will filter out, but at least we don't want to crash the whole parent component.