### PR TITLE
chore(travis): Set default version of Firefox to beta on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ before_script:
   - export JPM_FIREFOX_BINARY=`which firefox`
   - firefox -v
   - echo $JPM_FIREFOX_BINARY
+  - find firefox
 
 script:
   - npm run bundle

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,9 @@ language: node_js
 node_js:
   - "5.5.0"
 
+addons:
+  firefox: "latest-beta"
+
 before_install:
   - "export DISPLAY=:99.0"
   - "/sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -ac -screen 0 1280x1024x16 -extension RANDR"


### PR DESCRIPTION
Testing to see if this works. It should cause Travis-CI to replace the default Firefox 31.0 build with Firefox Beta from our CDN. If things work in Travis, later on we'll use **mozilla-download** to download Nightly (which will change in a future PR).

So best case our Travis will use Firefox 47/Nightly. Worst case Travis will use Firefox 45/Beta (which won't pass anyways until k88's other PR gets merged).

But currently Travis is randomly failing and just using it's default Firefox 31 which always fails. It's like playing Russian Roulette, but with a fully loaded gun.