### PR TITLE
fix(content): #177 Handle filtering of URLs and embedly data more gracefully

### DIFF
--- a/content-src/lib/filters.js
+++ b/content-src/lib/filters.js
@@ -1,0 +1,44 @@
+const urlParse = require("url-parse");
+
+const TEMP_MAX_LENGTH = 100;
+const ALLOWED_PROTOCOLS = new Set([
+  "http:",
+  "https:"
+]);
+const DISALLOWED_HOSTS = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0"
+]);
+
+function createFilter(definition) {
+  return function(item) {
+    let result = true;
+    const url = item && item.url && urlParse(item.url) || {};
+    definition.forEach(test => {
+      if (!test(item, url)) {
+        result = false;
+      }
+    });
+    return result;
+  };
+}
+
+const URL_FILTERS = [
+  (item) => !!item.url,
+  // This is temporary, until we can use POST-style requests
+  // see https://github.com/mozilla/embedly-proxy/issues/1
+  (item) => item.url && item.url.length < TEMP_MAX_LENGTH,
+  (item, url) => ALLOWED_PROTOCOLS.has(url.protocol),
+  (item, url) => !DISALLOWED_HOSTS.has(url.hostname)
+];
+
+const DATA_FILTERS = [
+  item => !(item.error_code || item.error_message)
+];
+
+module.exports = {
+  createFilter,
+  urlFilter: createFilter(URL_FILTERS),
+  siteFilter: createFilter(DATA_FILTERS)
+};

--- a/content-test/lib/filters.test.js
+++ b/content-test/lib/filters.test.js
@@ -1,0 +1,81 @@
+const {assert} = require("chai");
+const {createFilter, urlFilter, siteFilter} = require("lib/filters");
+
+const fakeData = {
+  get validUrls() {
+    return [
+      {url: "http://foo.com"},
+      {url: "https://foo.org"},
+      {url: "HttP://blah.com"}
+    ];
+  },
+  get validSite() {
+    return {url: "http://foo.com", description: "blah", title: "blah"};
+  }
+};
+
+describe("createFilter", () => {
+  it("should include all items if filters return true", () => {
+    const f = createFilter([() => true]);
+    const testData = [1, 2, 3];
+    assert.deepEqual(testData.filter(f), testData);
+  });
+  it("should remove all items if one filter returns false", () => {
+    const f = createFilter([() => true, () => false, () => true]);
+    const testData = [1, 2, 3];
+    assert.deepEqual(testData.filter(f), []);
+  });
+  it("should test individual items", () => {
+    const f = createFilter([item => item === 2]);
+    const testData = [1, 2, 3];
+    assert.deepEqual(testData.filter(f), [2]);
+  });
+});
+
+describe("urlFilter", () => {
+  it("should pass valid urls", () => {
+    assert.deepEqual(fakeData.validUrls.filter(urlFilter), fakeData.validUrls);
+  });
+  it("should require truthly urls", () => {
+    const urls = [{url: null}, {}, {url: ""}];
+    assert.deepEqual(urls.filter(urlFilter), []);
+  });
+  it("should remove urls > 100 characters", () => {
+    const urls = [{url: "http://" + new Array(100).join("d") + ".com"}];
+    assert.deepEqual(urls.filter(urlFilter), []);
+  });
+  it("should remove urls that do not start with http/https", () => {
+    const urls = [
+      {url: "places://foo/asdasd"},
+      {url: "ftp://asdasdads.com"},
+      {url: "garbage://asdasd.com"},
+    ];
+    assert.deepEqual(urls.filter(urlFilter), []);
+  });
+  it("should remove localhost urls, but not urls that start with localhost", () => {
+    const urls = [
+      {url: "http://localhost:4040"},
+      {url: "https://localhost:9999"},
+      {url: "HTTP://LOCALHOST"},
+      {url: "http://127.0.0.1:8000"},
+      {url: "http://0.0.0.0"},
+      {url: "http://localhost-foo.com"}
+    ];
+    assert.deepEqual(urls.filter(urlFilter), [{url: "http://localhost-foo.com"}]);
+  });
+});
+
+describe("siteFilter", () => {
+  it("should pass valid sites", () => {
+    assert.deepEqual([fakeData.validSite].filter(siteFilter), [fakeData.validSite]);
+  });
+  it("should remove sites that have errors from embedly", () => {
+    const validSite = fakeData.validSite;
+    const sites = [
+      Object.assign({}, validSite, {error_message: "there was an error"}),
+      Object.assign({}, validSite, {error_code: 400}),
+      Object.assign({}, validSite, {error_code: 400, type: "error", error_message: "there was an error"})
+    ];
+    assert.deepEqual(sites.filter(siteFilter), []);
+  });
+});

--- a/lib/PlacesProvider.js
+++ b/lib/PlacesProvider.js
@@ -28,7 +28,7 @@ XPCOMUtils.defineLazyGetter(this, "gPrincipal", function() {
 });
 
 // The maximum number of results PlacesProvider retrieves from history.
-const HISTORY_RESULTS_LIMIT = 25;
+const HISTORY_RESULTS_LIMIT = 20;
 
 /**
  * Singleton that checks if a given link should be displayed on about:newtab

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "activity-streams"
   ],
   "dependencies": {
-    "classnames": "^2.2.3",
+    "classnames": "2.2.3",
     "history": "1.17.0",
     "react": "0.14.7",
     "react-dom": "0.14.7",
@@ -27,7 +27,8 @@
     "react-router": "1.0.3",
     "redux": "3.2.0",
     "redux-logger": "2.4.0",
-    "redux-thunk": "1.0.3"
+    "redux-thunk": "1.0.3",
+    "url-parse": "1.0.5"
   },
   "devDependencies": {
     "babel": "^6.3.26",


### PR DESCRIPTION
Fixes #177 by filtering out error responses. I also added some URL filtering for long URLs (>100 characters), localhost, and non-http[s] protocols