### PR TITLE
Add hostname for top site, dev logger, deduping

### DIFF
--- a/content-src/actions/action-manager.js
+++ b/content-src/actions/action-manager.js
@@ -13,6 +13,14 @@ const am = new ActionManager([
   "NOTIFY_HISTORY_DELETE"
 ]);
 
+// This is a a set of actions that have sites in them,
+// so we can do stuff like filter them, add embedly data, etc.
+am.ACTIONS_WITH_SITES = new Set([
+  "TOP_FRECENT_SITES_RESPONSE",
+  "RECENT_BOOKMARKS_RESPONSE",
+  "RECENT_LINKS_RESPONSE"
+].map(type => am.type(type)));
+
 function Notify(type, data) {
   const action = {
     type,

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -1,7 +1,7 @@
 const React = require("react");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const DEFAULT_LENGTH = 6;
-const {toRGBString} = require("lib/utils");
+const {toRGBString, prettyUrl} = require("lib/utils");
 
 const TopSites = React.createClass({
   getDefaultProps() {
@@ -20,8 +20,11 @@ const TopSites = React.createClass({
           let title;
           let color;
           try {
-            title = site.parsedUrl.hostname.replace("www.", "");
+            title = prettyUrl(site.parsedUrl.hostname);
           } catch (e) {
+            //
+          }
+          if (!title) {
             title = site.provider_name || site.title;
           }
           try {

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -17,14 +17,25 @@ const TopSites = React.createClass({
       <h3 className="section-title">Top Sites</h3>
       <div className="tiles-wrapper">
         {sites.map((site) => {
-          const color = site.favicon_colors && site.favicon_colors[0] && site.favicon_colors[0].color || [333, 333, 333];
+          let title;
+          let color;
+          try {
+            title = site.parsedUrl.hostname.replace("www.", "");
+          } catch (e) {
+            title = site.provider_name || site.title;
+          }
+          try {
+            color = site.favicon_colors[0].color;
+          } catch (e) {
+            color = [251, 251, 251];
+          }
           const backgroundColor = toRGBString(...color, 0.8);
           return (<a key={site.url} className="tile" href={site.url} style={{backgroundColor}}>
             <div className="inner-border" />
             <div className="tile-img-container">
               <SiteIcon site={site} width={32} height={32} />
             </div>
-            <div className="tile-title">{site.provider_name}</div>
+            <div className="tile-title">{title}</div>
           </a>);
         })}
         {blankSites}
@@ -42,7 +53,8 @@ TopSites.propTypes = {
       url: React.PropTypes.string.isRequired,
       type: React.PropTypes.string,
       description: React.PropTypes.string,
-      provider_name: React.PropTypes.string
+      provider_name: React.PropTypes.string,
+      parsedUrl: React.PropTypes.object
     })
   ).isRequired
 };

--- a/content-src/lib/dedupe.js
+++ b/content-src/lib/dedupe.js
@@ -1,0 +1,33 @@
+const {log} =  require("lib/logger");
+const {prettyUrl} = require("lib/utils");
+
+function createDedupeKey(site) {
+  const parsed = site.parsedUrl;
+  if (!parsed) {
+    return null;
+  }
+  const host = prettyUrl(parsed.host);
+  const pathname = parsed.pathname.replace(/\/$/, "");
+  const query = parsed.query;
+  return host + pathname + query;
+}
+
+module.exports = {
+  createDedupeKey,
+  innerDedupe(sites) {
+    const urlMap = new Map();
+    sites.forEach(site => {
+      const key = createDedupeKey(site);
+      if (!key) {
+        log(`omitting ${site.url} because could not create key`);
+        return;
+      }
+      if (!urlMap.has(key)) {
+        urlMap.set(key, site);
+      } else {
+        log(`omitting ${site.url} because ${key} already exists`);
+      }
+    });
+    return Array.from(urlMap.values());
+  }
+};

--- a/content-src/lib/logger.js
+++ b/content-src/lib/logger.js
@@ -1,0 +1,7 @@
+module.exports = {
+  log() {
+    if (__CONFIG__.LOGGING) {
+      console.log.apply(console, arguments); // eslint-disable-line no-console
+    }
+  }
+};

--- a/content-src/lib/parse-url-middleware.js
+++ b/content-src/lib/parse-url-middleware.js
@@ -1,0 +1,26 @@
+const urlParse = require("url-parse");
+const am = require("actions/action-manager");
+
+module.exports = () => next => action => {
+
+  if (!am.ACTIONS_WITH_SITES.has(action.type)) {
+    return next(action);
+  }
+
+  if (action.error || !action.data || !action.data.length) {
+    return next(action);
+  }
+
+  const data = action.data.map(site => {
+    if (!site.url) {
+      return site;
+    }
+    const parsedUrl = urlParse(site.url);
+    if (!parsedUrl) {
+      return null;
+    }
+    return Object.assign({}, site, {parsedUrl});
+  }).filter(item => item);
+
+  next(Object.assign({}, action, {data}));
+};

--- a/content-src/lib/utils.js
+++ b/content-src/lib/utils.js
@@ -11,6 +11,6 @@ module.exports = {
     if (!url) {
       return "";
     }
-    return url.replace(/^https?:\/\/(www\.)?/i, "");
+    return url.replace(/^((https?:)?\/\/)?(www\.)?/i, "").toLowerCase();
   }
 };

--- a/content-src/store.js
+++ b/content-src/store.js
@@ -11,6 +11,7 @@ const channel = new Channel({
 const middleware = [
   thunk,
   channel.middleware,
+  require("lib/parse-url-middleware"),
   require("lib/embedly-middleware")
 ];
 

--- a/content-test/lib/dedupe.test.js
+++ b/content-test/lib/dedupe.test.js
@@ -1,0 +1,61 @@
+const {createDedupeKey, innerDedupe} = require("lib/dedupe");
+const {assert} = require("chai");
+const urlParse = require("url-parse");
+
+function createSite(url) {
+  return {url, parsedUrl: urlParse(url)};
+}
+
+describe("createDedupeKey", () => {
+  it("should return null if parsedUrl is missing", () => {
+    assert.isNull(createDedupeKey({url: ""}));
+  });
+  it("should create a key for a url", () => {
+    const site = createSite("http://facebook.com");
+    assert.equal(createDedupeKey(site), "facebook.com");
+  });
+  it("should ignore www.", () => {
+    const site = createSite("http://www.facebook.com");
+    assert.equal(createDedupeKey(site), "facebook.com");
+  });
+  it("should not replace www. if not the subdomain", () => {
+    const site = createSite("http://facebook.www.com");
+    assert.equal(createDedupeKey(site), "facebook.www.com");
+  });
+  it("should include the querystring", () => {
+    const site = createSite("https://facebook.com?foo=bar");
+    assert.equal(createDedupeKey(site), "facebook.com?foo=bar");
+  });
+  it("should strip a trailing /", () => {
+    const site = createSite("https://facebook.com/?foo=bar");
+    assert.equal(createDedupeKey(site), "facebook.com?foo=bar");
+  });
+  it("should include the path", () => {
+    const site = createSite("http://facebook.com/foo/bar");
+    assert.equal(createDedupeKey(site), "facebook.com/foo/bar");
+  });
+});
+
+describe("innerDedupe", () => {
+  it("should dedupe sites", () => {
+    const sites = [
+      "http://facebook.com",
+      "http://facebook.com",
+      "http://www.facebook.com",
+      "http://facebook.com/",
+      "https://facebook.com"
+    ].map(createSite);
+    const result = [
+      "http://facebook.com"
+    ].map(createSite);
+    assert.deepEqual(innerDedupe(sites), result);
+  });
+  it("should not ignore paths and querystrings", () => {
+    const sites = [
+      "http://facebook.com",
+      "http://facebook.com/foo",
+      "http://facebook.com?bar=bar"
+    ].map(createSite);
+    assert.deepEqual(innerDedupe(sites), sites);
+  });
+});

--- a/content-test/lib/utils.test.js
+++ b/content-test/lib/utils.test.js
@@ -31,12 +31,25 @@ describe("prettyUrl()", () => {
     assert.equal(utils.prettyUrl("https://mozilla.org/"), "mozilla.org/");
   });
 
+  it("should convert to lowercase", () => {
+    assert.equal(utils.prettyUrl("FOO.COM"), "foo.com");
+  });
+
   it("should strip out leading 'www.' subdomains", () => {
     assert.equal(utils.prettyUrl("https://www.mozilla.org/"), "mozilla.org/");
+  });
+
+  it("should strip out leading 'www.' for protocol-less URLS as well", () => {
+    assert.equal(utils.prettyUrl("www.foo.com"), "foo.com");
+    assert.equal(utils.prettyUrl("WWW.foo.com"), "foo.com");
   });
 
   it("should ignore non http[s] protocols", () => {
     let url = "gopher://github.com/mozilla/";
     assert.equal(utils.prettyUrl(url), url);
+  });
+
+  it("should not www if not first subdomain", () => {
+    assert.equal(utils.prettyUrl("foo.www.com"), "foo.www.com");
   });
 });


### PR DESCRIPTION
This uses `url-parse` to dedupe sites (i.e. remove sites that are basically equivalent). We also need to do some work to dedupe *across* components, but this is a good start

Fixes #180 
Fixes #182 
Fixes #194