### PR TITLE
Closes #164 - Time-constrained top frecent links API

### DIFF
--- a/content-src/actions/action-manager.js
+++ b/content-src/actions/action-manager.js
@@ -10,6 +10,8 @@ const am = new ActionManager([
   "RECEIVE_BOOKMARKS_CHANGES",
   "RECENT_LINKS_REQUEST",
   "RECENT_LINKS_RESPONSE",
+  "FRECENT_LINKS_REQUEST",
+  "FRECENT_LINKS_RESPONSE",
   "NOTIFY_HISTORY_DELETE"
 ]);
 
@@ -54,8 +56,12 @@ function RequestBookmarks() {
   return RequestExpect("RECENT_BOOKMARKS_REQUEST", "RECENT_BOOKMARKS_RESPONSE");
 }
 
-function RequestLinks() {
+function RequestRecentLinks() {
   return RequestExpect("RECENT_LINKS_REQUEST", "RECENT_LINKS_RESPONSE");
+}
+
+function RequestFrecentLinks() {
+  return RequestExpect("FRECENT_LINKS_REQUEST", "FRECENT_LINKS_RESPONSE");
 }
 
 function NotifyHistoryDelete(data) {
@@ -68,7 +74,8 @@ am.defineActions({
   RequestExpect,
   RequestTopFrecent,
   RequestBookmarks,
-  RequestLinks,
+  RequestRecentLinks,
+  RequestFrecentLinks,
   NotifyHistoryDelete,
 });
 

--- a/content-src/components/Base/Base.js
+++ b/content-src/components/Base/Base.js
@@ -8,7 +8,9 @@ const Base = React.createClass({
   componentDidMount() {
     this.props.dispatch(actions.RequestTopFrecent());
 
-    this.props.dispatch(actions.RequestLinks());
+    this.props.dispatch(actions.RequestRecentLinks());
+
+    this.props.dispatch(actions.RequestFrecentLinks());
 
     this.props.dispatch(actions.RequestBookmarks());
   },

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -82,6 +82,11 @@ ActivityStreams.prototype = {
           this.send(am.actions.Response("RECENT_LINKS_RESPONSE", links), worker);
         });
         break;
+      case am.type("FRECENT_LINKS_REQUEST"):
+        PlacesProvider.links.getFrecentLinks(msg.data).then(links => {
+          this.send(am.actions.Response("FRECENT_LINKS_RESPONSE", links), worker);
+        });
+        break;
       case am.type("NOTIFY_HISTORY_DELETE"):
         PlacesProvider.Links.deleteHistoryLink(msg.data);
         break;

--- a/lib/PlacesProvider.js
+++ b/lib/PlacesProvider.js
@@ -30,6 +30,9 @@ XPCOMUtils.defineLazyGetter(this, "gPrincipal", function() {
 // The maximum number of results PlacesProvider retrieves from history.
 const HISTORY_RESULTS_LIMIT = 25;
 
+// time interval for for frecent links query in milliseconds (72 hours).
+const FRECENT_RESULTS_TIME_LIMIT = 72 * 60 * 60 * 1000;
+
 /**
  * Singleton that checks if a given link should be displayed on about:newtab
  * or if we should rather not do it for security reasons. URIs that inherit
@@ -180,20 +183,38 @@ Links.prototype = {
   },
 
   /**
-   * Gets the top recent links
+   * Gets links from history based on supplied options
    *
-   * @param {Integer} options
-   *                  limit: Maximum number of results to return. Max 100.
+   * @param {Object} options
+   *        {Integer} limit: Maximum number of results to return. Max 100.
+   *        {Milliseconds} limitDate: Only return links fresher than limitDate
+   *        {String} order: if order=="frecency", orders by frecency, otherwise by recency
    *
    * @returns {Promise} Returns a promise with the array of links as payload.
    */
-  getRecentLinks: Task.async(function*(options={}) {
+  _getHistoryLinks: Task.async(function*(options={}) {
 
-    let {limit} = options;
+    let {limit, limitDate, order} = options;
     if (!limit || limit.options > HISTORY_RESULTS_LIMIT) {
       limit = HISTORY_RESULTS_LIMIT;
     }
 
+    // setup binding parameters
+    let params = {limit: limit};
+
+    // setup dateLimit binding and sql clause
+    let dateLimitClause = "";
+    if (limitDate) {
+      dateLimitClause = "AND moz_places.last_visit_date > :limitDate * 1000";
+      params.limitDate = limitDate;
+    }
+
+    // setup order by clause
+    let orderbyClause = (order == "frecency") ?
+                    "ORDER BY frecency DESC, lastVisitDate DESC, url" :
+                    "ORDER BY lastVisitDate DESC, frecency DESC, url" ;
+
+    // construct sql query
     let sqlQuery =  `SELECT moz_places.url as url,
                             moz_favicons.data as favicon,
                             moz_favicons.mime_type as mimeType,
@@ -209,18 +230,45 @@ Links.prototype = {
                      LEFT JOIN moz_bookmarks
                      ON moz_places.id = moz_bookmarks.fk
                      WHERE hidden = 0 AND last_visit_date NOTNULL
-                     ORDER BY lastVisitDate DESC, frecency DESC, url
+                     ${dateLimitClause}
+                     ${orderbyClause}
                      LIMIT :limit`;
 
     let links = yield this.executePlacesQuery(sqlQuery, {
                   columns: ["url", "favicon", "mimeType", "title", "lastVisitDate",
                             "frecency", "type", "bookmarkGuid", "bookmarkDateCreated"],
-                  params: {limit: limit}
+                  params: params
                 });
 
     links = this._faviconBytesToDataURI(links);
     return links.filter(link => LinkChecker.checkLoadURI(link.url));
   }),
+
+  /**
+   * Gets the top recent links
+   *
+   * @param {Integer} options
+   *                  limit: Maximum number of results to return. Max 100.
+   *
+   * @returns {Promise} Returns a promise with the array of links as payload.
+   */
+  getRecentLinks: function PlacesProvider_getRecentLinks(options) {
+    return this._getHistoryLinks(options);
+  },
+
+  /**
+   * Gets the top frecent links - visited in last 72 hours and ordered by frecency
+   *
+   * @param {Integer} options
+   *                  limit: Maximum number of results to return. Max 100.
+   *
+   * @returns {Promise} Returns a promise with the array of links as payload.
+   */
+  getFrecentLinks: function PlacesProvider_getFrecentLinks(options={}) {
+    options.order = "frecency";
+    options.limitDate = (new Date()).getTime() - FRECENT_RESULTS_TIME_LIMIT;
+    return this._getHistoryLinks(options);
+  },
 
   /**
    * Gets the top frecent sites.


### PR DESCRIPTION
Note a change to timeDaysAgo() - it will return microseconds instead of milliseconds.
This is done because FX keeps last_visit_date in microseconds

Fixes #164 