### PR TITLE
fix(content) #202: Use real labels for spotlight bookmarks v.s. visits

### DIFF
--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -1,4 +1,5 @@
 const React = require("react");
+const moment = require("moment");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const classNames = require("classnames");
 const DEFAULT_LENGTH = 3;
@@ -38,6 +39,16 @@ const SpotlightItem = React.createClass({
     const imageUrl = image.url;
     const description = site.description;
     const isPortrait = image.height > image.width;
+
+    let contextMessage;
+    if (site.bookmarkDateCreated) {
+      contextMessage = `Bookmarked ${moment(site.bookmarkDateCreated).fromNow()}`;
+    } else if (site.lastVisitDate) {
+      contextMessage = `Visited ${moment(site.lastVisitDate).fromNow()}`;
+    } else {
+      contextMessage = "Visited recently";
+    }
+
     return (<li className="spotlight-item">
       <a href={site.url} ref="link">
         <div className={classNames("spotlight-image", {portrait: isPortrait})} style={{backgroundImage: `url(${imageUrl})`}} ref="image">
@@ -49,7 +60,7 @@ const SpotlightItem = React.createClass({
               {site.title}
             </h4>
             <p className="spotlight-description" ref="description">{description}</p>
-            <div className="spotlight-type">Last opened on iPhone</div>
+            <div className="spotlight-context" ref="contextMessage">{contextMessage}</div>
           </div>
         </div>
         <div className="inner-border" />

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -70,7 +70,7 @@
     overflow: hidden;
   }
 
-  .spotlight-type {
+  .spotlight-context {
     padding: $spotlight-padding;
     position: absolute;
     bottom: 0;

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -1,4 +1,5 @@
 const {assert} = require("chai");
+const moment = require("moment");
 const Spotlight = require("components/Spotlight/Spotlight");
 const {SpotlightItem, getBestImage, IMG_WIDTH, IMG_HEIGHT} = Spotlight;
 const React = require("react");
@@ -11,6 +12,7 @@ const fakeSiteWithImage = {
   "title": "man throws alligator in wendys wptv dnt cnn",
   "url": "http://www.cnn.com/videos/tv/2016/02/09/man-throws-alligator-in-wendys-wptv-dnt.cnn",
   "description": "A Florida man faces multiple charges for throwing an alligator through a Wendy's drive-thru window. CNN's affiliate WPTV reports.",
+  "lastVisitDate": 1456426160465,
   "images": [
     {
       "url": "http://i2.cdn.turner.com/cnnnext/dam/assets/160209053130-man-throws-alligator-in-wendys-wptv-dnt-00004611-large-169.jpg",
@@ -109,6 +111,23 @@ describe("SpotlightItem", function() {
     });
     it("should render the description", () => {
       assert.include(instance.refs.description.innerHTML, fakeSite.description);
+    });
+    it("should render the lastVisitDate if it exists", () => {
+      assert.equal(instance.refs.contextMessage.innerHTML, `Visited ${moment(fakeSiteWithImage.lastVisitDate).fromNow()}`);
+    });
+    it("should render the bookmarkDateCreated if it exists", () => {
+      const props = Object.assign({}, fakeSite, {
+        bookmarkDateCreated: 1456426160465
+      });
+      instance = TestUtils.renderIntoDocument(<SpotlightItem {...props} />);
+      assert.equal(instance.refs.contextMessage.innerHTML, `Bookmarked ${moment(1456426160465).fromNow()}`);
+    });
+    it("should say 'Visited Recently' if no bookmark or timestamp are available", () => {
+      const props = Object.assign({}, fakeSite, {
+        lastVisitDate: null
+      });
+      instance = TestUtils.renderIntoDocument(<SpotlightItem {...props} />);
+      assert.equal(instance.refs.contextMessage.innerHTML, "Visited recently");
     });
   });
 });


### PR DESCRIPTION
Fixes #202 