### PR TITLE
fix(addon): #206 reset the NewTabURL on unload

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -277,6 +277,7 @@ ActivityStreams.prototype = {
     switch (reason){
       // can be one of: uninstall/disable/shutdown/upgrade/downgrade
       default:
+        NewTabURL.reset();
         this.workers.clear();
         this._removeListeners();
         this._pagemod.destroy();

--- a/lib/main.js
+++ b/lib/main.js
@@ -8,20 +8,21 @@ if (!storage.clientUUID) {
   storage.clientUUID = uuid();
 }
 
-Object.assign(exports, {
-  app: null,
+var app = null;
 
+Object.assign(exports, {
   main(options) {
 
     // options.loadReason can be install/enable/startup/upgrade/downgrade
     PlacesProvider.links.init();
     options.telemetry = false;
-    exports.app = new ActivityStreams(options);
+    app = new ActivityStreams(options);
   },
 
   onUnload(reason) {
-    if (exports.app) {
-      exports.app.unload(reason);
+    if (app) {
+      app.unload(reason);
+      app = null;
     }
     PlacesProvider.links.uninit();
   }


### PR DESCRIPTION
Turns out the `ActivityStreams.unload()` was never being called.

r? @oyiptong @k88hudson 