### PR TITLE
Closes #198 - Add some sort of pagination to Recent Links API query

### DIFF
--- a/content-src/actions/action-manager.js
+++ b/content-src/actions/action-manager.js
@@ -50,9 +50,6 @@ function RequestExpect(type, expect, options = {}) {
   if (options.timeout) {
     action.meta.timeout = options.timeout;
   }
-  if (options.query) {
-    action.query = options.query;
-  }
   if (options.data) {
     action.data = options.data;
   }

--- a/content-src/actions/action-manager.js
+++ b/content-src/actions/action-manager.js
@@ -53,6 +53,9 @@ function RequestExpect(type, expect, options = {}) {
   if (options.query) {
     action.query = options.query;
   }
+  if (options.data) {
+    action.data = options.data;
+  }
   return action;
 }
 
@@ -64,8 +67,8 @@ function RequestBookmarks() {
   return RequestExpect("RECENT_BOOKMARKS_REQUEST", "RECENT_BOOKMARKS_RESPONSE");
 }
 
-function RequestRecentLinks() {
-  return RequestExpect("RECENT_LINKS_REQUEST", "RECENT_LINKS_RESPONSE");
+function RequestRecentLinks(data) {
+  return RequestExpect("RECENT_LINKS_REQUEST", "RECENT_LINKS_RESPONSE", {data: data});
 }
 
 function RequestFrecentLinks() {

--- a/lib/PlacesProvider.js
+++ b/lib/PlacesProvider.js
@@ -191,14 +191,15 @@ Links.prototype = {
    *
    * @param {Object} options
    *        {Integer} limit: Maximum number of results to return. Max 20
-   *        {Milliseconds} limitDate: Only return links fresher than limitDate
+   *        {Milliseconds} beforeDate: Only return links older than beforeDate
+   *        {Milliseconds} afterDate: Only return links fresher than afterDate
    *        {String} order: if order=="frecency", orders by frecency, otherwise by recency
    *
    * @returns {Promise} Returns a promise with the array of links as payload.
    */
   _getHistoryLinks: Task.async(function*(options={}) {
 
-    let {limit, limitDate, order} = options;
+    let {limit, afterDate, beforeDate, order} = options;
     if (!limit || limit.options > HISTORY_RESULTS_LIMIT) {
       limit = HISTORY_RESULTS_LIMIT;
     }
@@ -206,11 +207,18 @@ Links.prototype = {
     // setup binding parameters
     let params = {limit: limit};
 
-    // setup dateLimit binding and sql clause
-    let dateLimitClause = "";
-    if (limitDate) {
-      dateLimitClause = "AND moz_places.last_visit_date > :limitDate * 1000";
-      params.limitDate = limitDate;
+    // setup afterDate binding and sql clause
+    let afterDateClause = "";
+    if (afterDate) {
+      afterDateClause = "AND moz_places.last_visit_date > :afterDate * 1000";
+      params.afterDate = afterDate;
+    }
+
+    // setup beforeDate binding and sql clause
+    let beforeDateClause = "";
+    if (beforeDate) {
+      beforeDateClause = "AND moz_places.last_visit_date < :beforeDate * 1000";
+      params.beforeDate = beforeDate;
     }
 
     // setup order by clause
@@ -234,7 +242,8 @@ Links.prototype = {
                      LEFT JOIN moz_bookmarks
                      ON moz_places.id = moz_bookmarks.fk
                      WHERE hidden = 0 AND last_visit_date NOTNULL
-                     ${dateLimitClause}
+                     ${afterDateClause}
+                     ${beforeDateClause}
                      ${orderbyClause}
                      LIMIT :limit`;
 
@@ -270,7 +279,7 @@ Links.prototype = {
    */
   getFrecentLinks: function PlacesProvider_getFrecentLinks(options={}) {
     options.order = "frecency";
-    options.limitDate = (new Date()).getTime() - FRECENT_RESULTS_TIME_LIMIT;
+    options.afterDate = (new Date()).getTime() - FRECENT_RESULTS_TIME_LIMIT;
     return this._getHistoryLinks(options);
   },
 

--- a/test/lib/utils.js
+++ b/test/lib/utils.js
@@ -48,6 +48,11 @@ function doThrow(error, stack) {
   throw(new Error(`Error at ${filename}`));
 }
 
+function doDump(object, trailer) {
+  dump(JSON.stringify(object, null, 1) + trailer); // eslint-disable-line no-undef
+}
+
 exports.doGetFile = doGetFile;
 exports.doThrow = doThrow;
+exports.doDump = doDump;
 

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -161,11 +161,17 @@ exports.test_Links_getRecentLinks = function*(assert) {
   assert.ok(!(links[0].bookmark || links[2].bookmark || links[3].bookmark), "other bookmarks are empty");
 
   // test beforeDate functionality
-  let beforeDate = timeDaysAgo(1) / 1000 - 1000;
-  links = yield provider.getRecentLinks({beforeDate: beforeDate});
+  let theDate = timeDaysAgo(1) / 1000 - 1000;
+  links = yield provider.getRecentLinks({beforeDate: theDate});
   assert.equal(links.length, 2, "should only see two links inserted 2 days ago");
   assert.equal(links[0].url, "https://mozilla3.com/2", "Expected 1-st link");
   assert.equal(links[1].url, "https://mozilla4.com/3", "Expected 2-nd link");
+
+  // test beforeDate functionality
+  links = yield provider.getRecentLinks({afterDate: theDate});
+  assert.equal(links.length, 2, "should only see two links inserted after the date");
+  assert.equal(links[0].url, "https://mozilla2.com/1", "Expected 1-st link");
+  assert.equal(links[1].url, "https://mozilla1.com/0", "Expected 2-nd link");
 };
 
 exports.test_Links_getFrecentLinks = function*(assert) {

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -159,6 +159,13 @@ exports.test_Links_getRecentLinks = function*(assert) {
   assert.equal(links[1].bookmarkDateCreated, new Date(bookmark.dateAdded).getTime(), "expected bookmark date for second link");
   assert.ok(isVisitDateOK(links[1].lastVisitDate), "visit date within expected range");
   assert.ok(!(links[0].bookmark || links[2].bookmark || links[3].bookmark), "other bookmarks are empty");
+
+  // test beforeDate functionality
+  let beforeDate = timeDaysAgo(1) / 1000 - 1000;
+  links = yield provider.getRecentLinks({beforeDate: beforeDate});
+  assert.equal(links.length, 2, "should only see two links inserted 2 days ago");
+  assert.equal(links[0].url, "https://mozilla3.com/2", "Expected 1-st link");
+  assert.equal(links[1].url, "https://mozilla4.com/3", "Expected 2-nd link");
 };
 
 exports.test_Links_getFrecentLinks = function*(assert) {


### PR DESCRIPTION
Simply add beforeDate in milliseconds to  RequestRecentLinks() as in

For example to get recent links 3 days or older, do call below
```
RequestRecentLinks({beforeDate: Date.now - 3*24*60*60*1000})
```
@rlr @k88hudson  let me know if this is something that you expected

Fixes #198 