### PR TITLE
fix(content): #192 Remove entropy check when choosing best image

### DIFF
--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -23,13 +23,7 @@ function getBestImage(images) {
     return true;
   });
 
-  if (!filteredImages.length) {
-    return null;
-  }
-
-  return filteredImages.reduce((prev, next) => {
-    return next.entropy > prev.entropy ? next : prev;
-  }) || null;
+  return filteredImages[0] || null;
 }
 
 const SpotlightItem = React.createClass({

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -151,11 +151,4 @@ describe("getBestImage", () => {
   it("should skip images without a url", () => {
     assert.equal(getBestImage([{height: IMG_HEIGHT, width: IMG_WIDTH}]), null);
   });
-  it("should use the image with the highest entropy", () => {
-    const images = [
-      {url: "foo.jpg", height: IMG_HEIGHT, width: IMG_WIDTH, entropy: 1},
-      {url: "bar.jpg", height: IMG_HEIGHT, width: IMG_WIDTH, entropy: 3}
-    ];
-    assert.equal(getBestImage(images), images[1]);
-  });
 });


### PR DESCRIPTION
This removes the entropy check when choosing the best image.

Fixes #192.

@k88hudson @pdehaan r?