### PR TITLE
feat(content): #220 Dedupe sites via redux selectors

### DIFF
--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -11,6 +11,8 @@ const ActivityFeedItem = React.createClass({
   render() {
     const site = this.props;
     const title = site.title;
+    const date = site.dateDisplay;
+
     return (<li className={classNames("feed-item", {bookmark: site.bookmarkGuid})}>
       <SiteIcon ref="icon" className="feed-icon" site={site} width={ICON_SIZE} height={ICON_SIZE} />
       <div className="feed-details">
@@ -19,7 +21,7 @@ const ActivityFeedItem = React.createClass({
           <a className="feed-link" href={site.url} ref="link">{prettyUrl(site.url)}</a>
         </div>
         <div className="feed-stats">
-          <div ref="lastVisit">{site.lastVisitDate && moment(site.lastVisitDate).format("h:mma")}</div>
+          <div ref="lastVisit">{date && moment(date).format("h:mma")}</div>
           <div>...</div>
         </div>
       </div>
@@ -32,7 +34,8 @@ ActivityFeedItem.propTypes = {
   images: React.PropTypes.array,
   title: React.PropTypes.string,
   bookmarkTitle: React.PropTypes.string,
-  type: React.PropTypes.string
+  type: React.PropTypes.string,
+  dateDisplay: React.PropTypes.number
 };
 
 const ActivityFeed = React.createClass({
@@ -55,11 +58,12 @@ ActivityFeed.propTypes = {
 function groupSitesByDate(sites) {
   let groupedSites = new Map();
   for (let site of sites) {
-    if (!Number.isInteger(site.lastVisitDate)) {
+    const date = site.dateDisplay;
+    if (!Number.isInteger(date)) {
       continue;
     }
 
-    let day = moment(site.lastVisitDate).startOf("day").format();
+    let day = moment(date).startOf("day").format();
     if (!groupedSites.has(day)) {
       groupedSites.set(day, []);
     }
@@ -70,10 +74,17 @@ function groupSitesByDate(sites) {
 
 const GroupedActivityFeed = React.createClass({
   getDefaultProps() {
-    return {length: DEFAULT_LENGTH};
+    return {
+      length: DEFAULT_LENGTH,
+      dateKey: "lastVisitDate"
+    };
   },
   render() {
-    const sites = this.props.sites.slice(0, this.props.length);
+    const sites = this.props.sites
+      .slice(0, this.props.length)
+      .map(site => {
+        return Object.assign({}, site, {dateDisplay: site[this.props.dateKey]});
+      });
     const groupedSites = groupSitesByDate(sites);
     return (<div className="grouped-activity-feed">
       {this.props.title &&
@@ -100,7 +111,8 @@ const GroupedActivityFeed = React.createClass({
 GroupedActivityFeed.propTypes = {
   sites: React.PropTypes.array.isRequired,
   length: React.PropTypes.number,
-  title: React.PropTypes.string
+  title: React.PropTypes.string,
+  dateKey: React.PropTypes.string
 };
 
 module.exports = ActivityFeed;

--- a/content-src/components/Base/Base.js
+++ b/content-src/components/Base/Base.js
@@ -1,5 +1,6 @@
 const React = require("react");
 const {connect} = require("react-redux");
+const {justDispatch} = require("selectors/selectors");
 const {actions} = require("actions/action-manager");
 
 const Base = React.createClass({
@@ -21,4 +22,4 @@ const Base = React.createClass({
   }
 });
 
-module.exports = connect(() => ({}))(Base);
+module.exports = connect(justDispatch)(Base);

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -1,6 +1,6 @@
 const React = require("react");
 const {connect} = require("react-redux");
-
+const {dedupedSites} = require("selectors/selectors");
 const TopSites = require("components/TopSites/TopSites");
 const {GroupedActivityFeed} = require("components/ActivityFeed/ActivityFeed");
 const Spotlight = require("components/Spotlight/Spotlight");
@@ -26,11 +26,11 @@ const NewTabPage = React.createClass({
           </section>
 
           <section>
-            <Spotlight sites={props.History.rows} />
+            <Spotlight sites={props.Spotlight.rows} />
           </section>
 
           <section>
-            <GroupedActivityFeed title="Top Activity" sites={props.History.rows} length={6} />
+            <GroupedActivityFeed title="Top Activity" sites={props.TopActivity.rows} length={6} />
           </section>
         </div>
       </div>
@@ -38,9 +38,5 @@ const NewTabPage = React.createClass({
   }
 });
 
-function select(state) {
-  return state;
-}
-
-module.exports = connect(select)(NewTabPage);
+module.exports = connect(dedupedSites)(NewTabPage);
 module.exports.NewTabPage = NewTabPage;

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -3,37 +3,11 @@ const moment = require("moment");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const classNames = require("classnames");
 const DEFAULT_LENGTH = 3;
-const IMG_HEIGHT = 226;
-const IMG_WIDTH =  124;
-
-function getBestImage(images) {
-  if (!images || !images.length) {
-    return null;
-  }
-  const filteredImages = images.filter(image => {
-    if (!image.url) {
-      return false;
-    }
-    if (!image.width || image.width < IMG_WIDTH) {
-      return false;
-    }
-    if (!image.height || image.height < IMG_HEIGHT) {
-      return false;
-    }
-    return true;
-  });
-
-  if (!filteredImages.length) {
-    return null;
-  }
-
-  return filteredImages[0];
-}
 
 const SpotlightItem = React.createClass({
   render() {
     const site = this.props;
-    const image = getBestImage(site.images);
+    const image = site.bestImage;
     const imageUrl = image.url;
     const description = site.description;
     const isPortrait = image.height > image.width;
@@ -71,15 +45,10 @@ const SpotlightItem = React.createClass({
 
 SpotlightItem.propTypes = {
   url: React.PropTypes.string.isRequired,
-  images: React.PropTypes.arrayOf(
-    React.PropTypes.shape({
-      url: React.PropTypes.string.isRequired
-    }).isRequired
-  ).isRequired,
+  bestImage: React.PropTypes.object.isRequired,
   favicon_url: React.PropTypes.string,
-  icons: React.PropTypes.array,
-  title: React.PropTypes.string,
-  description: React.PropTypes.string
+  title: React.PropTypes.string.isRequired,
+  description: React.PropTypes.string.isRequired
 };
 
 const Spotlight = React.createClass({
@@ -87,17 +56,7 @@ const Spotlight = React.createClass({
     return {length: DEFAULT_LENGTH};
   },
   render() {
-    const sites = this.props.sites
-      .filter(site => {
-        // Don't use sites that don't look good
-        return !!(
-          getBestImage(site.images) &&
-          site.title &&
-          site.description &&
-          site.title !== site.description
-        );
-      })
-      .slice(0, this.props.length);
+    const sites = this.props.sites.slice(0, this.props.length);
     const blankSites = [];
     for (let i = 0; i < (this.props.length - sites.length); i++) {
       blankSites.push(<li className="spotlight-item spotlight-placeholder" key={`blank-${i}`} />);
@@ -119,6 +78,3 @@ Spotlight.propTypes = {
 
 module.exports = Spotlight;
 module.exports.SpotlightItem = SpotlightItem;
-module.exports.getBestImage = getBestImage;
-module.exports.IMG_HEIGHT = IMG_HEIGHT;
-module.exports.IMG_WIDTH =  IMG_WIDTH;

--- a/content-src/components/TimelinePage/TimelineBookmarks.js
+++ b/content-src/components/TimelinePage/TimelineBookmarks.js
@@ -1,5 +1,7 @@
 const React = require("react");
 const {connect} = require("react-redux");
+const {dedupedSites} = require("selectors/selectors");
+
 const {GroupedActivityFeed} = require("components/ActivityFeed/ActivityFeed");
 const Spotlight = require("components/Spotlight/Spotlight");
 
@@ -7,11 +9,11 @@ const TimelineBookmarks = React.createClass({
   render() {
     const props = this.props;
     return (<div className="wrapper">
-      <Spotlight sites={props.Bookmarks.rows} />
+      <Spotlight sites={props.Spotlight.rows} />
       <GroupedActivityFeed title="Just now" sites={props.Bookmarks.rows} length={20} />
     </div>);
   }
 });
 
-module.exports = connect(({History, Bookmarks}) => ({History, Bookmarks}))(TimelineBookmarks);
+module.exports = connect(dedupedSites)(TimelineBookmarks);
 module.exports.TimelineBookmarks = TimelineBookmarks;

--- a/content-src/components/TimelinePage/TimelineHistory.js
+++ b/content-src/components/TimelinePage/TimelineHistory.js
@@ -1,17 +1,19 @@
 const React = require("react");
 const {connect} = require("react-redux");
+const {dedupedSites} = require("selectors/selectors");
+
 const {GroupedActivityFeed} = require("components/ActivityFeed/ActivityFeed");
 const Spotlight = require("components/Spotlight/Spotlight");
 
 const TimelineHistory = React.createClass({
   render() {
-    const {History} = this.props;
+    const props = this.props;
     return (<div className="wrapper">
-      <Spotlight sites={History.rows} />
-      <GroupedActivityFeed title="Just now" sites={History.rows} length={20} />
+      <Spotlight sites={props.Spotlight.rows} />
+      <GroupedActivityFeed title="Just now" sites={props.History.rows} length={20} />
     </div>);
   }
 });
 
-module.exports = connect(({History}) => ({History}))(TimelineHistory);
+module.exports = connect(dedupedSites)(TimelineHistory);
 module.exports.TimelineHistory = TimelineHistory;

--- a/content-src/lib/dedupe.js
+++ b/content-src/lib/dedupe.js
@@ -1,33 +1,19 @@
-const {log} =  require("lib/logger");
 const {prettyUrl} = require("lib/utils");
+const dedupe = require("fancy-dedupe");
+const urlParse = require("url-parse");
 
 function createDedupeKey(site) {
-  const parsed = site.parsedUrl;
-  if (!parsed) {
+  if (!site.url) {
     return null;
   }
+  const parsed = site.parsedUrl || urlParse(site.url, false);
   const host = prettyUrl(parsed.host);
   const pathname = parsed.pathname.replace(/\/$/, "");
-  const query = parsed.query;
+  const query = parsed.query || "";
   return host + pathname + query;
 }
 
-module.exports = {
-  createDedupeKey,
-  innerDedupe(sites) {
-    const urlMap = new Map();
-    sites.forEach(site => {
-      const key = createDedupeKey(site);
-      if (!key) {
-        log(`omitting ${site.url} because could not create key`);
-        return;
-      }
-      if (!urlMap.has(key)) {
-        urlMap.set(key, site);
-      } else {
-        log(`omitting ${site.url} because ${key} already exists`);
-      }
-    });
-    return Array.from(urlMap.values());
-  }
-};
+dedupe.defaults.createKey = createDedupeKey;
+
+module.exports = dedupe;
+module.exports.createDedupeKey = createDedupeKey;

--- a/content-src/lib/embedly-middleware.js
+++ b/content-src/lib/embedly-middleware.js
@@ -1,7 +1,7 @@
 const am = require("actions/action-manager");
 const embedlyEndpoint = __CONFIG__.EMBEDLY_ENDPOINT;
 const {urlFilter, siteFilter} = require("lib/filters");
-const {innerDedupe} = require("lib/dedupe");
+const dedupe = require("lib/dedupe");
 const {sanitizeUrl} = require("lib/utils");
 
 function buildQuery(items) {
@@ -26,7 +26,7 @@ module.exports = () => next => action => {
     return next(action);
   }
 
-  const sites = innerDedupe(action.data.filter(urlFilter));
+  const sites = dedupe.one(action.data.filter(urlFilter));
 
   const filteredAction = Object.assign({}, action, {data: sites});
 

--- a/content-src/lib/getBestImage.js
+++ b/content-src/lib/getBestImage.js
@@ -1,0 +1,29 @@
+const IMG_HEIGHT = 226;
+const IMG_WIDTH =  124;
+
+module.exports = function getBestImage(images) {
+  if (!images || !images.length) {
+    return null;
+  }
+  const filteredImages = images.filter(image => {
+    if (!image.url) {
+      return false;
+    }
+    if (!image.width || image.width < IMG_WIDTH) {
+      return false;
+    }
+    if (!image.height || image.height < IMG_HEIGHT) {
+      return false;
+    }
+    return true;
+  });
+
+  if (!filteredImages.length) {
+    return null;
+  }
+
+  return filteredImages[0];
+};
+
+module.exports.IMG_HEIGHT = IMG_HEIGHT;
+module.exports.IMG_WIDTH = IMG_WIDTH;

--- a/content-src/lib/parse-url-middleware.js
+++ b/content-src/lib/parse-url-middleware.js
@@ -15,7 +15,7 @@ module.exports = () => next => action => {
     if (!site.url) {
       return site;
     }
-    const parsedUrl = urlParse(site.url, true);
+    const parsedUrl = urlParse(site.url, false);
     if (!parsedUrl) {
       return null;
     }

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -1,0 +1,49 @@
+const {createSelector} = require("reselect");
+const dedupe = require("lib/dedupe");
+const getBestImage = require("lib/getBestImage");
+
+const SPOTLIGHT_LENGTH = module.exports.SPOTLIGHT_LENGTH = 3;
+const TOP_SITES_LENGTH = module.exports.TOP_SITES_LENGTH = 6;
+
+module.exports.justDispatch = (() => ({}));
+
+const selectSpotlight = module.exports.selectSpotlight = createSelector(
+  [state => state.History],
+  (History) => {
+    const rows = History.rows
+    .map(site => {
+      const bestImage = getBestImage(site.images);
+      return Object.assign({}, site, {bestImage});
+    })
+    .filter(site => {
+      return (
+        site.bestImage &&
+        site.title &&
+        site.description &&
+        site.title !== site.description
+      );
+    });
+    return Object.assign({}, History, {rows});
+  }
+);
+
+module.exports.dedupedSites = createSelector(
+  [
+    state => state.TopSites,
+    state => state.History,
+    state => state.Bookmarks,
+    selectSpotlight
+  ],
+  (TopSites, History, Bookmarks, Spotlight) => {
+    let [topSitesRows, spotlightRows] = dedupe.group([TopSites.rows.slice(0, TOP_SITES_LENGTH), Spotlight.rows]);
+    spotlightRows = spotlightRows.slice(0, SPOTLIGHT_LENGTH);
+    const topActivityRows = dedupe.group([topSitesRows, spotlightRows, History.rows])[2];
+    return {
+      TopSites: Object.assign({}, TopSites, {rows: topSitesRows}),
+      Spotlight: Object.assign({}, History, {rows: spotlightRows}),
+      TopActivity: Object.assign({}, History, {rows: topActivityRows}),
+      History,
+      Bookmarks
+    };
+  }
+);

--- a/content-test/components/ActivityFeed.test.js
+++ b/content-test/components/ActivityFeed.test.js
@@ -11,7 +11,7 @@ const moment = require("moment");
 const fakeSites = require("test/test-utils").mockData.Bookmarks.rows;
 const fakeSite = {
   "title": "man throws alligator in wendys wptv dnt cnn",
-  "lastVisitDate": 1456426160465,
+  "dateDisplay": 1456426160465,
   "url": "http://www.cnn.com/videos/tv/2016/02/09/man-throws-alligator-in-wendys-wptv-dnt.cnn",
   "description": "A Florida man faces multiple charges for throwing an alligator through a Wendy's drive-thru window. CNN's affiliate WPTV reports.",
   "images": [
@@ -25,7 +25,7 @@ const fakeSite = {
   ]
 };
 const fakeSiteWithBookmark = Object.assign({}, fakeSite, {
-  "bookmarkDateCreate": 1456426165218,
+  "bookmarkDateCreated": 1456426165218,
   "bookmarkGuid": "G6LXclyo_WAj"
 });
 
@@ -80,7 +80,7 @@ describe("ActivityFeedItem", function() {
     });
     it("should render the time", () => {
       const lastVisitEl = instance.refs.lastVisit;
-      assert.equal(lastVisitEl.innerHTML, moment(fakeSite.lastVisitDate).format("h:mma"));
+      assert.equal(lastVisitEl.innerHTML, moment(fakeSite.dateDisplay).format("h:mma"));
     });
     it("should not have a bookmark class if no bookmarkGuid", () => {
       assert.notInclude(el.className, "bookmark");

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -1,12 +1,14 @@
 const {assert} = require("chai");
 const React = require("react");
 const TestUtils = require("react-addons-test-utils");
-
-const {NewTabPage} = require("components/NewTabPage/NewTabPage");
+const ConnectedNewTabPage = require("components/NewTabPage/NewTabPage");
+const {NewTabPage} = ConnectedNewTabPage;
 const {GroupedActivityFeed} = require("components/ActivityFeed/ActivityFeed");
 const TopSites = require("components/TopSites/TopSites");
+const Spotlight = require("components/Spotlight/Spotlight");
+const {mockData, renderWithProvider} = require("test/test-utils");
 
-const fakeProps = require("test/test-utils").mockData;
+const fakeProps = mockData;
 
 describe("NewTabPage", () => {
   let instance;
@@ -23,8 +25,19 @@ describe("NewTabPage", () => {
     assert.equal(topSites.props.sites, fakeProps.TopSites.rows);
   });
 
+  it("should render Spotlight components with correct data", () => {
+    const spotlightSites = TestUtils.findRenderedComponentWithType(instance, Spotlight);
+    assert.equal(spotlightSites.props.sites, fakeProps.Spotlight.rows);
+  });
+
   it("should render GroupedActivityFeed with correct data", () => {
     const activityFeed = TestUtils.findRenderedComponentWithType(instance, GroupedActivityFeed);
-    assert.equal(activityFeed.props.sites, fakeProps.History.rows);
+    assert.equal(activityFeed.props.sites, fakeProps.TopActivity.rows);
+  });
+
+  it("should render connected component with correct props", () => {
+    const container = renderWithProvider(ConnectedNewTabPage);
+    const inner = TestUtils.findRenderedComponentWithType(container, NewTabPage);
+    Object.keys(fakeProps).forEach(key => assert.property(inner.props, key));
   });
 });

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -1,38 +1,26 @@
 const {assert} = require("chai");
 const moment = require("moment");
 const Spotlight = require("components/Spotlight/Spotlight");
-const {SpotlightItem, getBestImage, IMG_WIDTH, IMG_HEIGHT} = Spotlight;
+const {SpotlightItem} = Spotlight;
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
-const fakeSpotlightItems = require("lib/fake-data").History.rows;
+const fakeSpotlightItems = require("test/test-utils").mockData.Spotlight.rows;
 
 const fakeSiteWithImage = {
   "title": "man throws alligator in wendys wptv dnt cnn",
   "url": "http://www.cnn.com/videos/tv/2016/02/09/man-throws-alligator-in-wendys-wptv-dnt.cnn",
   "description": "A Florida man faces multiple charges for throwing an alligator through a Wendy's drive-thru window. CNN's affiliate WPTV reports.",
   "lastVisitDate": 1456426160465,
-  "images": [
-    {
-      "url": "http://i2.cdn.turner.com/cnnnext/dam/assets/160209053130-man-throws-alligator-in-wendys-wptv-dnt-00004611-large-169.jpg",
-      "height": 259,
-      "width": 460,
-      "entropy": 3.98714569089,
-      "size": 14757
-    },
-  ]
+  "bestImage": {
+    "url": "http://i2.cdn.turner.com/cnnnext/dam/assets/160209053130-man-throws-alligator-in-wendys-wptv-dnt-00004611-large-169.jpg",
+    "height": 259,
+    "width": 460,
+    "entropy": 3.98714569089,
+    "size": 14757
+  }
 };
-
-// Tests that provided sites don't get rendered, because they don't
-// match the conditions for spotlight to use them
-function assertInvalidSite(site) {
-  // merge valid site with invalid props
-  const testSite = Object.assign({}, fakeSiteWithImage, site);
-  const testInstance = TestUtils.renderIntoDocument(<Spotlight sites={[testSite]} length={5} />);
-  const children = TestUtils.scryRenderedComponentsWithType(testInstance, SpotlightItem);
-  assert.equal(children.length, 0);
-}
 
 describe("Spotlight", function() {
   let instance;
@@ -49,30 +37,6 @@ describe("Spotlight", function() {
     it("should render a SpotlightItem for each item", () => {
       const children = TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem);
       assert.equal(children.length, 3);
-    });
-    it("should skip sites that do not have a title", () => {
-      assertInvalidSite({
-        title: null
-      });
-    });
-    it("should skip sites that do not have a description", () => {
-      assertInvalidSite({
-        description: null
-      });
-    });
-    it("should skip sites for which the title equals the description", () => {
-      assertInvalidSite({
-        title: "foo",
-        description: "foo"
-      });
-    });
-    it("should skip sites that do not have an images prop or an empty array", () => {
-      assertInvalidSite({
-        images: null
-      });
-      assertInvalidSite({
-        images: []
-      });
     });
   });
 });
@@ -100,7 +64,7 @@ describe("SpotlightItem", function() {
       assert.include(instance.refs.icon.props.site, fakeSite);
     });
     it("should render the image", () => {
-      assert.include(instance.refs.image.style.backgroundImage, fakeSite.images[0].url);
+      assert.include(instance.refs.image.style.backgroundImage, fakeSite.bestImage.url);
     });
     it("should render the url link", () => {
       const linkEl = instance.refs.link;
@@ -129,33 +93,5 @@ describe("SpotlightItem", function() {
       instance = TestUtils.renderIntoDocument(<SpotlightItem {...props} />);
       assert.equal(instance.refs.contextMessage.innerHTML, "Visited recently");
     });
-  });
-});
-
-describe("getBestImage", () => {
-  it("should return null if images is falsey", () => {
-    assert.equal(getBestImage(), null);
-    assert.equal(getBestImage(null), null);
-  });
-  it("should return null if images is an empty array", () => {
-    assert.equal(getBestImage([]), null);
-  });
-  it("should use a valid image that is big enough", () => {
-    const img = {url: "foo.jpg", height: IMG_HEIGHT, width: IMG_WIDTH};
-    assert.equal(getBestImage([img]), img);
-  });
-  it("should skip images that are too small", () => {
-    assert.equal(getBestImage([{url: "foo.jpg", height: IMG_HEIGHT - 1, width: IMG_WIDTH}]), null);
-    assert.equal(getBestImage([{url: "foo.jpg", height: IMG_HEIGHT, width: IMG_WIDTH - 1}]), null);
-  });
-  it("should skip images without a url", () => {
-    assert.equal(getBestImage([{height: IMG_HEIGHT, width: IMG_WIDTH}]), null);
-  });
-  it("should use the first image in the array", () => {
-    const images = [
-      {url: "foo.jpg", height: IMG_HEIGHT, width: IMG_WIDTH, entropy: 1},
-      {url: "bar.jpg", height: IMG_HEIGHT, width: IMG_WIDTH, entropy: 3}
-    ];
-    assert.equal(getBestImage(images), images[0]);
   });
 });

--- a/content-test/components/TimelinePage.test.js
+++ b/content-test/components/TimelinePage.test.js
@@ -1,11 +1,15 @@
 const {assert} = require("chai");
 const React = require("react");
 const TestUtils = require("react-addons-test-utils");
+
 const TimelinePage = require("components/TimelinePage/TimelinePage");
-const {TimelineHistory} = require("components/TimelinePage/TimelineHistory");
-const {TimelineBookmarks} = require("components/TimelinePage/TimelineBookmarks");
+const ConnectedTimelineHistory = require("components/TimelinePage/TimelineHistory");
+const {TimelineHistory} = ConnectedTimelineHistory;
+const ConnectedTimelineBookmarks = require("components/TimelinePage/TimelineBookmarks");
+const {TimelineBookmarks} = ConnectedTimelineBookmarks;
 const {GroupedActivityFeed} = require("components/ActivityFeed/ActivityFeed");
-const {mockData} = require("test/test-utils");
+
+const {mockData, renderWithProvider} = require("test/test-utils");
 
 describe("Timeline", () => {
 
@@ -52,6 +56,12 @@ describe("Timeline", () => {
       const activityFeed = TestUtils.findRenderedComponentWithType(instance, GroupedActivityFeed);
       assert.equal(activityFeed.props.sites, fakeProps.History.rows);
     });
+
+    it("should render the connected container with the correct props", () => {
+      const container = renderWithProvider(ConnectedTimelineHistory);
+      const inner = TestUtils.findRenderedComponentWithType(container, TimelineHistory);
+      Object.keys(fakeProps).forEach(key => assert.property(inner.props, key));
+    });
   });
 
   describe("TimelineBookmarks", () => {
@@ -68,6 +78,12 @@ describe("Timeline", () => {
     it("should render GroupedActivityFeed with correct data", () => {
       const activityFeed = TestUtils.findRenderedComponentWithType(instance, GroupedActivityFeed);
       assert.equal(activityFeed.props.sites, fakeProps.Bookmarks.rows);
+    });
+
+    it("should render the connected container with the correct props", () => {
+      const container = renderWithProvider(ConnectedTimelineBookmarks);
+      const inner = TestUtils.findRenderedComponentWithType(container, TimelineBookmarks);
+      Object.keys(fakeProps).forEach(key => assert.property(inner.props, key));
     });
   });
 

--- a/content-test/index.js
+++ b/content-test/index.js
@@ -5,3 +5,5 @@ chai.use(require("chai-as-promised"));
 chai.should();
 
 files.forEach(file => req(file));
+
+// require("test/components/NewTabPage.test.js");

--- a/content-test/lib/dedupe.test.js
+++ b/content-test/lib/dedupe.test.js
@@ -1,13 +1,15 @@
-const {createDedupeKey, innerDedupe} = require("lib/dedupe");
 const {assert} = require("chai");
 const urlParse = require("url-parse");
+
+const dedupe = require("lib/dedupe");
+const {createDedupeKey} = dedupe;
 
 function createSite(url) {
   return {url, parsedUrl: urlParse(url)};
 }
 
 describe("createDedupeKey", () => {
-  it("should return null if parsedUrl is missing", () => {
+  it("should return null if url is missing", () => {
     assert.isNull(createDedupeKey({url: ""}));
   });
   it("should create a key for a url", () => {
@@ -36,7 +38,7 @@ describe("createDedupeKey", () => {
   });
 });
 
-describe("innerDedupe", () => {
+describe("dedupe", () => {
   it("should dedupe sites", () => {
     const sites = [
       "http://facebook.com",
@@ -48,7 +50,7 @@ describe("innerDedupe", () => {
     const result = [
       "http://facebook.com"
     ].map(createSite);
-    assert.deepEqual(innerDedupe(sites), result);
+    assert.deepEqual(dedupe.one(sites), result);
   });
   it("should not ignore paths and querystrings", () => {
     const sites = [
@@ -56,6 +58,6 @@ describe("innerDedupe", () => {
       "http://facebook.com/foo",
       "http://facebook.com?bar=bar"
     ].map(createSite);
-    assert.deepEqual(innerDedupe(sites), sites);
+    assert.deepEqual(dedupe.one(sites), sites);
   });
 });

--- a/content-test/lib/getBestImage.test.js
+++ b/content-test/lib/getBestImage.test.js
@@ -1,0 +1,32 @@
+const {assert} = require("chai");
+
+const getBestImage = require("lib/getBestImage");
+const {IMG_WIDTH, IMG_HEIGHT} = getBestImage;
+
+describe("getBestImage", () => {
+  it("should return null if images is falsey", () => {
+    assert.equal(getBestImage(), null);
+    assert.equal(getBestImage(null), null);
+  });
+  it("should return null if images is an empty array", () => {
+    assert.equal(getBestImage([]), null);
+  });
+  it("should use a valid image that is big enough", () => {
+    const img = {url: "foo.jpg", height: IMG_HEIGHT, width: IMG_WIDTH};
+    assert.equal(getBestImage([img]), img);
+  });
+  it("should skip images that are too small", () => {
+    assert.equal(getBestImage([{url: "foo.jpg", height: IMG_HEIGHT - 1, width: IMG_WIDTH}]), null);
+    assert.equal(getBestImage([{url: "foo.jpg", height: IMG_HEIGHT, width: IMG_WIDTH - 1}]), null);
+  });
+  it("should skip images without a url", () => {
+    assert.equal(getBestImage([{height: IMG_HEIGHT, width: IMG_WIDTH}]), null);
+  });
+  it("should use the first image in the array", () => {
+    const images = [
+      {url: "foo.jpg", height: IMG_HEIGHT, width: IMG_WIDTH, entropy: 1},
+      {url: "bar.jpg", height: IMG_HEIGHT, width: IMG_WIDTH, entropy: 3}
+    ];
+    assert.equal(getBestImage(images), images[0]);
+  });
+});

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -1,0 +1,121 @@
+const {assert} = require("chai");
+const {connect} = require("react-redux");
+const React = require("react");
+const TestUtils = require("react-addons-test-utils");
+const dedupe = require("lib/dedupe");
+
+const {
+  justDispatch,
+  selectSpotlight,
+  dedupedSites,
+  SPOTLIGHT_LENGTH
+} = require("selectors/selectors");
+const {rawMockData, createMockProvider} = require("test/test-utils");
+
+const validSpotlightSite = {
+  "title": "man throws alligator in wendys wptv dnt cnn",
+  "url": "http://www.cnn.com/videos/tv/2016/02/09/man-throws-alligator-in-wendys-wptv-dnt.cnn",
+  "description": "A Florida man faces multiple charges for throwing an alligator through a Wendy's drive-thru window. CNN's affiliate WPTV reports.",
+  "lastVisitDate": 1456426160465,
+  "images": [{
+    "url": "http://i2.cdn.turner.com/cnnnext/dam/assets/160209053130-man-throws-alligator-in-wendys-wptv-dnt-00004611-large-169.jpg",
+    "height": 259,
+    "width": 460,
+    "entropy": 3.98714569089,
+    "size": 14757
+  }]
+};
+
+const fakeState = rawMockData;
+const EmptyComponent = React.createClass({render: () => (<div />)});
+
+function connectSelectorToComponent(selector, InnerComponent = EmptyComponent) {
+  const Provider = createMockProvider();
+  const Connected = connect(justDispatch)(InnerComponent);
+  const instance = TestUtils.renderIntoDocument(<Provider><Connected /></Provider>);
+  return TestUtils.findRenderedComponentWithType(instance, InnerComponent);
+}
+
+describe("selectors", () => {
+  describe("justDispatch", () => {
+    it("should return an empty state object", () => {
+      assert.deepEqual(justDispatch(fakeState), {});
+    });
+    it("should pass dispatch to inner element", () => {
+      const instance = connectSelectorToComponent(justDispatch);
+      assert.property(instance.props, "dispatch");
+      assert.isFunction(instance.props.dispatch);
+    });
+  });
+  describe("selectSpotlight", () => {
+    let state = selectSpotlight(fakeState);
+
+    // Tests that provided sites don't get selected, because they don't
+    // match the conditions for spotlight to use them
+    function assertInvalidSite(site) {
+      const testSite = Object.assign({}, validSpotlightSite, site);
+      const emptyState = selectSpotlight({History: {rows: [testSite]}});
+      assert.lengthOf(emptyState.rows, 0);
+    }
+
+    it("should have the same properties as History", () => {
+      assert.deepEqual(Object.keys(state), Object.keys(fakeState.History));
+    });
+    it("should add a bestImage for each item", () => {
+      state.rows.forEach(site => {
+        assert.property(site, "bestImage");
+        assert.isObject(site.bestImage);
+        assert.property(site.bestImage, "url");
+      });
+    });
+    it("should skip sites that do not have a title", () => {
+      assertInvalidSite({
+        title: null
+      });
+    });
+    it("should skip sites that do not have a description", () => {
+      assertInvalidSite({
+        description: null
+      });
+    });
+    it("should skip sites for which the title equals the description", () => {
+      assertInvalidSite({
+        title: "foo",
+        description: "foo"
+      });
+    });
+    it("should skip sites that do not have an images prop or an empty array", () => {
+      assertInvalidSite({
+        images: null
+      });
+      assertInvalidSite({
+        images: []
+      });
+    });
+  });
+  describe("dedupedSites", () => {
+    let state = dedupedSites(fakeState);
+    it("should return the right properties", () => {
+      [
+        "Bookmarks",
+        "History",
+        "Spotlight",
+        "TopActivity",
+        "TopSites"
+      ].forEach(prop => {
+        assert.property(state, prop);
+      });
+    });
+    it("should not modify Bookmarks or History", () => {
+      assert.equal(state.Bookmarks, fakeState.Bookmarks);
+      assert.equal(state.History, fakeState.History);
+    });
+    it("should use first 3 items of selectSpotlight for Spotlight", () => {
+      assert.deepEqual(state.Spotlight.rows, selectSpotlight(fakeState).rows.slice(0, SPOTLIGHT_LENGTH));
+    });
+    it("should dedupe TopSites, Spotlight, and TopActivity", () => {
+      const groups = [state.TopSites.rows, state.Spotlight.rows, state.TopActivity.rows];
+      assert.deepEqual(groups, dedupe.group(groups));
+    });
+  });
+});

--- a/content-test/test-utils.js
+++ b/content-test/test-utils.js
@@ -1,20 +1,31 @@
 const React = require("react");
 const {Provider} = require("react-redux");
 const mockData = require("lib/fake-data");
+const {dedupedSites} = require("selectors/selectors");
+const TestUtils = require("react-addons-test-utils");
+
+function createMockProvider(data = mockData) {
+  const store = {
+    getState: () => data,
+    dispatch: () => {},
+    subscribe: () => {}
+  };
+  store.subscribe = () => {};
+  return React.createClass({
+    render() {
+      return (<Provider store={store}>{this.props.children}</Provider>);
+    }
+  });
+}
+
+function renderWithProvider(Connected) {
+  const ProviderWrapper = createMockProvider();
+  return TestUtils.renderIntoDocument(<ProviderWrapper><Connected /></ProviderWrapper>);
+}
 
 module.exports = {
-  mockData,
-  createMockProvider(data = mockData) {
-    const store = {
-      getState: () => data,
-      dispatch: () => {},
-      subscribe: () => {}
-    };
-    store.subscribe = () => {};
-    return React.createClass({
-      render() {
-        return (<Provider store={store}>{this.props.children}</Provider>);
-      }
-    });
-  }
+  rawMockData: mockData,
+  mockData: dedupedSites(mockData),
+  createMockProvider,
+  renderWithProvider
 };

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "updateLink": "https://moz-activity-streams.s3.amazonaws.com/dist/activity-streams-latest.xpi",
   "dependencies": {
     "classnames": "2.2.3",
+    "fancy-dedupe": "0.1.0",
     "history": "1.17.0",
     "moment": "2.11.2",
     "react": "0.14.7",
@@ -31,6 +32,7 @@
     "redux": "3.2.0",
     "redux-logger": "2.4.0",
     "redux-thunk": "1.0.3",
+    "reselect": "^2.0.3",
     "url-parse": "1.0.5"
   },
   "devDependencies": {
@@ -104,7 +106,7 @@
     "test:lint": "eslint . && jscs . && sass-lint -v -q",
     "test:jpm": "jpm test -b beta",
     "test:karma": "NODE_ENV=test karma start --browsers FirefoxNightly",
-    "tdd": "karma start --no-single-run",
+    "tdd": "NODE_ENV=test karma start --no-single-run --browsers Chrome",
     "package": "npm run bundle && jpm xpi && mv @activity-streams-$npm_package_version.xpi dist/activity-streams-$npm_package_version.xpi",
     "travis": "npm-run-all travis:*",
     "travis:eslint": "npm run test:lint",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -54,6 +54,7 @@ module.exports = {
       "components": absolute("./content-src/components"),
       "reducers": absolute("./content-src/reducers"),
       "actions": absolute("./content-src/actions"),
+      "selectors": absolute("./content-src/selectors"),
       "lib": absolute("./content-src/lib"),
       "strings": absolute("./strings"),
       "test": absolute("./content-test")

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -44,7 +44,7 @@ scripts:
     karma: NODE_ENV=test karma start --browsers FirefoxNightly
 
 # tdd: Run content tests continuously
-  tdd: karma start --no-single-run
+  tdd: NODE_ENV=test karma start --no-single-run --browsers Chrome
 
 # package: Build add-on
   package: =>bundle && jpm xpi && mv @activity-streams-$npm_package_version.xpi dist/activity-streams-$npm_package_version.xpi


### PR DESCRIPTION
This patch adds "selectors" as a means of calculating derived data used by components (in this case, de-duping each data type, and deriving `Spotlight` and `TopActivity` from `History`).

Selectors are just functions passed to `connect`, when connecting components to redux:

```js
// Instead of:
//   const selector  = (state => state);
const selector = require("selectors/selectors").dedupedItems;

connect(selector)(NewTabPage)
```

Selectors use [reselect](https://github.com/reactjs/reselect) to memoize derived data, which is nice.

For the deduping I wrote a small library called [fancy-dedupe](https://github.com/k88hudson/fancy-dedupe), which basically dedupes stuff on custom keys, with a custom compare function, and across multiple arrays.

Fixes #220 