### PR TITLE
chore(lint): Fix a few ESLint and Sass-lint warnings

### DIFF
--- a/content-src/components/ActivityFeed/ActivityFeed.scss
+++ b/content-src/components/ActivityFeed/ActivityFeed.scss
@@ -3,7 +3,7 @@
     border-bottom: solid 1px $faintest-black;
 
     &:last-child {
-      border-bottom: none;
+      border-bottom: 0;
     }
   }
 }

--- a/lib/PerfMeter.js
+++ b/lib/PerfMeter.js
@@ -97,7 +97,7 @@ PerfMeter.prototype = {
 
       // when tab is reloaded, the worker will be re-attached to the tab and another
       // WORKER_ATTACHED event will be sent. In which case we re-initialize tabData
-      if (tag == "WORKER_ATTACHED") {
+      if (tag === "WORKER_ATTACHED") {
         if (tabData.workerWasAttached) {
           // tab is reloaded - re-initialize it. Since reload does not generate TAB_OPEN
           // and TAB_READY events, we introduce articficial ones starting at 0

--- a/test/test-PerfMeter.js
+++ b/test/test-PerfMeter.js
@@ -128,9 +128,9 @@ exports.test_PerfMeter_events = function*(assert) {
   // if the tab structure doesn't re-initialize after reload
   verifyPerfEvents(events, assert);
   // verify the first three expected events on reload
-  assert.ok(events[0].tag === "TAB_RELOAD" && events[0].start == 0, "Expected TAB_RELOAD");
-  assert.ok(events[1].tag === "TAB_READY" && events[0].start == 0, "Expected TAB_READY");
-  assert.ok(events[2].tag === "WORKER_ATTACHED" && events[0].start == 0, "Expected WORKER_ATTACHED");
+  assert.ok(events[0].tag === "TAB_RELOAD" && events[0].start === 0, "Expected TAB_RELOAD");
+  assert.ok(events[1].tag === "TAB_READY" && events[0].start === 0, "Expected TAB_READY");
+  assert.ok(events[2].tag === "WORKER_ATTACHED" && events[0].start === 0, "Expected WORKER_ATTACHED");
 
   tabData.tab.close();
 };
@@ -194,7 +194,7 @@ exports.test_PerfMeter_tab_hygiene = function*(assert) {
     let closeCounter = 4;
     function onClose() {
       closeCounter--;
-      if (closeCounter == 0) {
+      if (closeCounter === 0) {
         resolve();
       }
     }


### PR DESCRIPTION
Noticed this while doing some local builds.

We still have 1 ESLint warning, but wasn't sure if we should ignore that warning using `// eslint-disable-line no-console`, or use something better than `console.info()` in PerfMeter.

```
> eslint . && jscs . && sass-lint -v -q

/Users/pdehaan/dev/github/activity-streams/lib/PerfMeter.js
  142:7  warning  Unexpected console statement  no-console

✖ 1 problem (0 errors, 1 warning)
```