### PR TITLE
chore(lint): Fix eqeqeq warning, and promote it to an ESLint error

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -35,7 +35,7 @@
     "comma-dangle": 0,
     "computed-property-spacing": [2, "never"],
     "default-case": 0,
-    "eqeqeq": 1,
+    "eqeqeq": 2,
     "func-names": 0,
     "func-style": 0,
     "global-require": 0,

--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -157,7 +157,7 @@ TabTracker.prototype = {
 
   onPerfLoadComplete: function(subject, topic, data) {
     let eventData = JSON.parse(data);
-    if (eventData.tabId == this._tabData.tab_id) {
+    if (eventData.tabId === this._tabData.tab_id) {
       this._tabData.load_latency = eventData.events[eventData.events.length - 1].start;
     }
   },


### PR DESCRIPTION
Promotes ESLint `eqeqeq` warning to an unforgiving build breaking error.