### PR TITLE
Closes #309 - Add total_bookmarks and total_history_size to telemetry ping

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -253,15 +253,16 @@ ActivityStreams.prototype = {
    */
   _asyncBuildPlacesCache: Task.async(function*() {
     if (simplePrefs.prefs["query.cache"]) {
+      let notifyData = {};
       yield Promise.all([
           this._memoized.getTopFrecentSites(),
           this._memoized.getRecentBookmarks(),
           this._memoized.getRecentLinks(),
           this._memoized.getFrecentLinks(),
-          this._memoized.getHistorySize(),
-          this._memoized.getBookmarksSize(),
+          this._memoized.getHistorySize().then(result => {notifyData.historySize = result;}),
+          this._memoized.getBookmarksSize().then(result => {notifyData.bookmarkSize = result;}),
       ]);
-      Services.obs.notifyObservers(null, "activity-streams-places-cache-complete", this._memoized);
+      Services.obs.notifyObservers(null, "activity-streams-places-cache-complete", JSON.stringify(notifyData));
     }
   }),
 

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -47,14 +47,15 @@ function ActivityStreams(options = {}) {
   this._setupListeners();
   this._setupButton();
   NewTabURL.override(`${this.options.pageURL}#/`);
-  this._telemetrySender = new TelemetrySender();
-  this._tabTracker = new TabTracker(this.appURLs, options.clientID);
 
   this._appURLHider = new AppURLHider(this.appURLs);
   this._perfMeter = new PerfMeter(this.appURLs);
 
   this._memoizer = new Memoizer();
   this._memoized = this._get_memoized(this._memoizer);
+
+  this._telemetrySender = new TelemetrySender();
+  this._tabTracker = new TabTracker(this.appURLs, options.clientID, this._memoized);
 
   this._rebuildInProgress = true;
   this._asyncBuildPlacesCache().then(() => {
@@ -253,16 +254,15 @@ ActivityStreams.prototype = {
    */
   _asyncBuildPlacesCache: Task.async(function*() {
     if (simplePrefs.prefs["query.cache"]) {
-      let notifyData = {};
       yield Promise.all([
           this._memoized.getTopFrecentSites(),
           this._memoized.getRecentBookmarks(),
           this._memoized.getRecentLinks(),
           this._memoized.getFrecentLinks(),
-          this._memoized.getHistorySize().then(result => {notifyData.historySize = result;}),
-          this._memoized.getBookmarksSize().then(result => {notifyData.bookmarkSize = result;}),
+          this._memoized.getHistorySize(),
+          this._memoized.getBookmarksSize(),
       ]);
-      Services.obs.notifyObservers(null, "activity-streams-places-cache-complete", JSON.stringify(notifyData));
+      Services.obs.notifyObservers(null, "activity-streams-places-cache-complete", null);
     }
   }),
 

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -241,6 +241,8 @@ ActivityStreams.prototype = {
       getRecentBookmarks: cache.memoize("getRecentBookmarks", PlacesProvider.links.getRecentBookmarks.bind(linksObj)),
       getRecentLinks: cache.memoize("getRecentLinks", PlacesProvider.links.getRecentLinks.bind(linksObj)),
       getFrecentLinks: cache.memoize("getFrecentLinks", PlacesProvider.links.getFrecentLinks.bind(linksObj)),
+      getHistorySize: cache.memoize("getHistorySize", PlacesProvider.links.getHistorySize.bind(linksObj)),
+      getBookmarksSize: cache.memoize("getBookmarksSize", PlacesProvider.links.getBookmarksSize.bind(linksObj)),
     };
   },
 
@@ -256,8 +258,10 @@ ActivityStreams.prototype = {
           this._memoized.getRecentBookmarks(),
           this._memoized.getRecentLinks(),
           this._memoized.getFrecentLinks(),
+          this._memoized.getHistorySize(),
+          this._memoized.getBookmarksSize(),
       ]);
-      Services.obs.notifyObservers(null, "activity-streams-places-cache-complete", null);
+      Services.obs.notifyObservers(null, "activity-streams-places-cache-complete", this._memoized);
     }
   }),
 
@@ -269,7 +273,9 @@ ActivityStreams.prototype = {
         "getTopFrecentSites",
         "getRecentBookmarks",
         "getRecentLinks",
-        "getFrecentLinks"
+        "getFrecentLinks",
+        "getHistorySize",
+        "getBookmarksSize",
     ]);
   },
 

--- a/lib/PlacesProvider.js
+++ b/lib/PlacesProvider.js
@@ -450,6 +450,34 @@ Links.prototype = {
   },
 
   /**
+   * Gets History size
+   *
+   * @returns {Promise} Returns a promise with the count of moz_places records
+   */
+  getHistorySize: Task.async(function*() {
+    let sqlQuery = `SELECT count(1) as count
+                    FROM moz_places
+                    WHERE hidden = 0 AND last_visit_date NOT NULL`;
+
+    let result = yield this.executePlacesQuery(sqlQuery);
+    return result[0][0];
+  }),
+
+  /**
+   * Gets Bookmarks count
+   *
+   * @returns {Promise} Returns a promise with the count of bookmarks
+   */
+  getBookmarksSize: Task.async(function*() {
+    let sqlQuery = `SELECT count(1) as count
+                    FROM moz_bookmarks
+                    WHERE type = :type`;
+
+    let result = yield this.executePlacesQuery(sqlQuery, {params: {type: Bookmarks.TYPE_BOOKMARK}});
+    return result[0][0];
+  }),
+
+  /**
    * Executes arbitrary query against places database
    *
    * @param {String} aSql

--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -12,12 +12,12 @@ const TELEMETRY_PREF = "telemetry";
 const COMPLETE_NOTIF = "tab-session-complete";
 const PERF_LOG_COMPLETE_NOTIF = "performance-log-complete";
 
-function TabTracker(trackableURLs, clientID, placesGate) {
+function TabTracker(trackableURLs, clientID, placesQueries) {
   this._tabData = {};
 
   this._clientID = clientID;
   this._trackableURLs = trackableURLs;
-  this._placesGate = placesGate;
+  this._placesQueries = placesQueries;
   this.onOpen = this.onOpen.bind(this);
   this.onPerfLoadComplete = this.onPerfLoadComplete.bind(this);
 
@@ -158,8 +158,8 @@ TabTracker.prototype = {
     tab.on("close", this.logClose("close"));
 
     // update history and bookmark sizes
-    this._placesGate.getHistorySize().then(size => {this._tabData.historySize = size;});
-    this._placesGate.getBookmarksSize().then(size => {this._tabData.bookmarkSize = size;});
+    this._placesQueries.getHistorySize().then(size => {this._tabData.historySize = size;});
+    this._placesQueries.getBookmarksSize().then(size => {this._tabData.bookmarkSize = size;});
   },
 
   _onPrefChange() {

--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -11,16 +11,15 @@ Cu.import("resource://gre/modules/Locale.jsm");
 const TELEMETRY_PREF = "telemetry";
 const COMPLETE_NOTIF = "tab-session-complete";
 const PERF_LOG_COMPLETE_NOTIF = "performance-log-complete";
-const CACHE_UPDATE_NOTIF = "activity-streams-places-cache-complete";
 
-function TabTracker(trackableURLs, clientID) {
+function TabTracker(trackableURLs, clientID, placesGate) {
   this._tabData = {};
 
   this._clientID = clientID;
   this._trackableURLs = trackableURLs;
+  this._placesGate = placesGate;
   this.onOpen = this.onOpen.bind(this);
   this.onPerfLoadComplete = this.onPerfLoadComplete.bind(this);
-  this.onCacheUpdate = this.onCacheUpdate.bind(this);
 
   this._onPrefChange = this._onPrefChange.bind(this);
   this.enabled = simplePrefs.prefs[TELEMETRY_PREF];
@@ -40,7 +39,6 @@ TabTracker.prototype = {
   _addListeners() {
     tabs.on("open", this.onOpen);
     Services.obs.addObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
-    Services.obs.addObserver(this.onCacheUpdate, CACHE_UPDATE_NOTIF);
   },
 
   _removeListeners() {
@@ -52,7 +50,6 @@ TabTracker.prototype = {
     }
     tabs.removeListener("open", this.onOpen);
     Services.obs.removeObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
-    Services.obs.removeObserver(this.onCacheUpdate, CACHE_UPDATE_NOTIF);
   },
 
   _clearTabData() {
@@ -159,6 +156,10 @@ TabTracker.prototype = {
     tab.on("activate", this.logActivate);
     tab.on("deactivate", this.logDeactivate("unfocus"));
     tab.on("close", this.logClose("close"));
+
+    // update history and bookmark sizes
+    this._placesGate.getHistorySize().then(size => {this._tabData.historySize = size;});
+    this._placesGate.getBookmarksSize().then(size => {this._tabData.bookmarkSize = size;});
   },
 
   _onPrefChange() {
@@ -176,12 +177,6 @@ TabTracker.prototype = {
     if (eventData.tabId == this._tabData.tab_id) {
       this._tabData.load_latency = eventData.events[eventData.events.length - 1].start;
     }
-  },
-
-  onCacheUpdate: function(subject, topic, data) {
-    let {historySize, bookmarkSize} = JSON.parse(data);
-    this._tabData.historySize = historySize;
-    this._tabData.bookmarkSize = bookmarkSize;
   },
 };
 

--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -11,6 +11,7 @@ Cu.import("resource://gre/modules/Locale.jsm");
 const TELEMETRY_PREF = "telemetry";
 const COMPLETE_NOTIF = "tab-session-complete";
 const PERF_LOG_COMPLETE_NOTIF = "performance-log-complete";
+const CACHE_UPDATE_NOTIF = "activity-streams-places-cache-complete";
 
 function TabTracker(trackableURLs, clientID) {
   this._tabData = {};
@@ -19,12 +20,12 @@ function TabTracker(trackableURLs, clientID) {
   this._trackableURLs = trackableURLs;
   this.onOpen = this.onOpen.bind(this);
   this.onPerfLoadComplete = this.onPerfLoadComplete.bind(this);
+  this.onCacheUpdate = this.onCacheUpdate.bind(this);
 
   this._onPrefChange = this._onPrefChange.bind(this);
   this.enabled = simplePrefs.prefs[TELEMETRY_PREF];
   if (this.enabled) {
-    tabs.on("open", this.onOpen);
-    Services.obs.addObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
+    this._addListeners();
   }
   simplePrefs.on(TELEMETRY_PREF, this._onPrefChange);
 }
@@ -36,6 +37,12 @@ TabTracker.prototype = {
     return this._tabData;
   },
 
+  _addListeners() {
+    tabs.on("open", this.onOpen);
+    Services.obs.addObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
+    Services.obs.addObserver(this.onCacheUpdate, CACHE_UPDATE_NOTIF);
+  },
+
   _removeListeners() {
     for (let tab of this._openTabs) {
       tab.removeListener("ready", this.logReady);
@@ -45,6 +52,16 @@ TabTracker.prototype = {
     }
     tabs.removeListener("open", this.onOpen);
     Services.obs.removeObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
+    Services.obs.removeObserver(this.onCacheUpdate, CACHE_UPDATE_NOTIF);
+  },
+
+  _clearTabData() {
+    // keep history and bookmarks sizes of the current tabData
+    let {historySize, bookmarkSize} = this._tabData;
+    this._tabData = {
+      historySize: historySize,
+      bookmarkSize: bookmarkSize,
+    };
   },
 
   uninit() {
@@ -72,7 +89,7 @@ TabTracker.prototype = {
       this._tabData.session_duration = 0;
       delete this._tabData.start_time;
       Services.obs.notifyObservers(null, COMPLETE_NOTIF, JSON.stringify(this._tabData));
-      this._tabData = {};
+      this._clearTabData();
       return;
     }
     if (this._tabData.start_time) {
@@ -80,7 +97,7 @@ TabTracker.prototype = {
       delete this._tabData.start_time;
     }
     Services.obs.notifyObservers(null, COMPLETE_NOTIF, JSON.stringify(this._tabData));
-    this._tabData = {};
+    this._clearTabData();
   },
 
   logReady(tab) {
@@ -147,8 +164,7 @@ TabTracker.prototype = {
   _onPrefChange() {
     let newValue = simplePrefs.prefs.telemetry;
     if (!this.enabled && newValue) {
-      tabs.on("open", this.onOpen);
-      Services.obs.addObserver(this.onPerfLoadComplete, PERF_LOG_COMPLETE_NOTIF);
+      this._addListeners();
     } else if (this.enabled && !newValue) {
       this._removeListeners();
     }
@@ -160,6 +176,12 @@ TabTracker.prototype = {
     if (eventData.tabId == this._tabData.tab_id) {
       this._tabData.load_latency = eventData.events[eventData.events.length - 1].start;
     }
+  },
+
+  onCacheUpdate: function(subject, topic, data) {
+    let {historySize, bookmarkSize} = JSON.parse(data);
+    this._tabData.historySize = historySize;
+    this._tabData.bookmarkSize = bookmarkSize;
   },
 };
 

--- a/test/lib/PlacesTestUtils.js
+++ b/test/lib/PlacesTestUtils.js
@@ -1,4 +1,4 @@
-/* globals XPCOMUtils, Task, PlacesUtils, NetUtil, Services */
+/* globals XPCOMUtils, Task, PlacesUtils, NetUtil, Services, Bookmarks */
 "use strict";
 
 const {Ci, Cu, components} = require("chrome");
@@ -13,6 +13,9 @@ XPCOMUtils.defineLazyModuleGetter(this, "PlacesUtils",
 
 XPCOMUtils.defineLazyModuleGetter(this, "NetUtil",
   "resource://gre/modules/NetUtil.jsm");
+
+XPCOMUtils.defineLazyModuleGetter(this, "Bookmarks",
+  "resource://gre/modules/Bookmarks.jsm");
 
 const PlacesTestUtils = Object.freeze({
 
@@ -171,6 +174,14 @@ const PlacesTestUtils = Object.freeze({
     let stmt = conn.createStatement("DELETE FROM moz_bookmarks WHERE type = 1");
     stmt.executeStep();
   },
+
+  /*
+   * Insert and bookmark a vists
+   */
+  insertAndBookmarkVisit: Task.async(function*(url) {
+    yield this.addVisits({uri: NetUtil.newURI(url), visitDate: Date.now(), transition: PlacesUtils.history.TRANSITION_LINK});
+    yield Bookmarks.insert({url: url, parentGuid: "root________", type: Bookmarks.TYPE_BOOKMARK});
+  }),
 });
 
 exports.PlacesTestUtils = PlacesTestUtils;

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -277,6 +277,8 @@ exports.test_Links_getRecentBookmarks_Order = function*(assert) {
 
   let links = yield provider.getRecentBookmarks();
   assert.equal(links.length, 0, "empty bookmarks yields empty links");
+  let bookmarksSize = yield provider.getBookmarksSize();
+  assert.equal(bookmarksSize, 0, "empty bookmarks yields 0 size");
 
   let base64URL = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAA" +
     "AAAA6fptVAAAACklEQVQI12NgAAAAAgAB4iG8MwAAAABJRU5ErkJggg==";
@@ -358,6 +360,9 @@ exports.test_Links_getRecentBookmarks_Order = function*(assert) {
   for (let i = 0; i < links.length; i++) {
     assert.ok(links[i].lastModified < yesterday, "bookmark lastModifed date is before yesterday");
   }
+
+  bookmarksSize = yield provider.getBookmarksSize();
+  assert.equal(bookmarksSize, createdBookmarks.length, "expected count of bookmarks");
 
   // cleanup
   yield Bookmarks.remove({guid: folder.guid});
@@ -584,6 +589,20 @@ exports.test_Links__faviconBytesToDataURI = function(assert) {
     let result = provider._faviconBytesToDataURI(test);
     assert.equal(JSON.stringify(clone), JSON.stringify(result), "favicon converted to data uri");
   }
+};
+
+exports.test_Links_getHistorySize = function*(assert) {
+  let provider = PlacesProvider.links;
+
+  let size = yield provider.getHistorySize();
+  assert.equal(size, 0, "empty history has 0 size");
+
+  // add a visit
+  let testURI = NetUtil.newURI("http://mozilla.com");
+  yield PlacesTestUtils.addVisits(testURI);
+
+  size = yield provider.getHistorySize();
+  assert.equal(size, 1, "expected history size");
 };
 
 before(exports, function*() {

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -278,8 +278,6 @@ exports.test_TabTracker_latency = function*(assert) {
 };
 
 exports.test_TabTracker_History_And_Bookmark_Reporting = function*(assert) {
-  PlacesTestUtils.clearBookmarks();
-  yield PlacesTestUtils.clearHistory();
   isTabDataEmpty(assert);
   tabs.open(ACTIVITY_STREAMS_URL);
   let pingData = yield waitForPageLoadAndSessionComplete();
@@ -311,6 +309,13 @@ exports.test_TabTracker_History_And_Bookmark_Reporting = function*(assert) {
 };
 
 before(exports, function*() {
+  // we have to clear bookmarks and history before tests
+  // to ensure that the app does not pick history or
+  // bookmarks sizes from the previous test runs
+  PlacesTestUtils.clearBookmarks();
+  yield PlacesTestUtils.clearHistory();
+
+  // initialize the app now
   let clientID = yield ClientID.getClientID();
   simplePrefs.prefs.telemetry = true;
   app = new ActivityStreams({clientID});

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -64,24 +64,6 @@ function checkLoadUnloadReasons(assert, pingData, expectedLoadReasons, expectedU
   }
 }
 
-function isTabDataEmpty(assert) {
-  // practically app.tabData should always be {} on startup, however the app
-  // may fire "activity-streams-places-cache-complete" notification, and that
-  // will create historySize and bookmarksSize entries in the tabData object
-  // To be on a safe side, let's make sure that tabData is either empty or
-  // contains only startup keys
-  let tabKeys = Object.keys(app.tabData);
-  if (tabKeys.length == 0) {
-    // nothing to check
-    return;
-  }
-  let allowedKeysOnStartup = ["historySize", "bookmarkSize"];
-  assert.equal(tabKeys.length, allowedKeysOnStartup.length, "Expected number of tabData keys on startup");
-  for (let key of allowedKeysOnStartup) {
-    assert.notEqual(app.tabData[key], undefined, `${key} is an attribute in tab data on startup`);
-  }
-}
-
 function waitForPageLoadAndSessionComplete() {
   return new Promise(resolve => {
     let onOpen = function(tab) {
@@ -110,7 +92,7 @@ function waitForPageLoadAndSessionComplete() {
 }
 
 exports.test_TabTracker_init = function(assert) {
-  isTabDataEmpty(assert);
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
 };
 
 exports.test_TabTracker_open_close_tab = function*(assert) {
@@ -139,7 +121,7 @@ exports.test_TabTracker_open_close_tab = function*(assert) {
     Services.obs.addObserver(Observer, "tab-session-complete");
   });
 
-  isTabDataEmpty(assert);
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
 
   tabs.open(ACTIVITY_STREAMS_URL);
   yield tabClosedPromise;
@@ -172,7 +154,7 @@ exports.test_TabTracker_reactivating = function*(assert) {
     tabs.on("pageshow", onOpen);
   });
 
-  isTabDataEmpty(assert);
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
 
   tabs.open("http://foo.com");
   tabs.open(ACTIVITY_STREAMS_URL);
@@ -241,7 +223,7 @@ exports.test_TabTracker_refresh = function*(assert) {
     tabs.on("ready", onOpen);
   });
 
-  isTabDataEmpty(assert);
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
 
   tabs.open(ACTIVITY_STREAMS_URL);
 
@@ -271,14 +253,14 @@ exports.test_TabTracker_prefs = function*(assert) {
 };
 
 exports.test_TabTracker_latency = function*(assert) {
-  isTabDataEmpty(assert);
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
   tabs.open(ACTIVITY_STREAMS_URL);
   let pingData = yield waitForPageLoadAndSessionComplete();
   checkLoadUnloadReasons(assert, [pingData], ["newtab"], ["close"], true);
 };
 
 exports.test_TabTracker_History_And_Bookmark_Reporting = function*(assert) {
-  isTabDataEmpty(assert);
+  assert.deepEqual(app.tabData, {}, "tabData starts out empty");
   tabs.open(ACTIVITY_STREAMS_URL);
   let pingData = yield waitForPageLoadAndSessionComplete();
   checkLoadUnloadReasons(assert, [pingData], ["newtab"], ["close"], true);


### PR DESCRIPTION
  * added PlacesProvider API to get history and bookmarks sizes
  * added corresponding queries to memoizer cache
  * added notification data containing history and bookmarks sizes to "activity-streams-places-cache-complete" event
  * added "activity-streams-places-cache-complete" observer to TabTracker which updates appropriate keys inside tabData
  * a bunch of test changes 

Fixes #309