### PR TITLE
fix(content): #352 Renamed Spotlight and Top Activity

### DIFF
--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -39,7 +39,7 @@ const NewTabPage = React.createClass({
           </section>
 
           <section>
-            <GroupedActivityFeed title="Top Activity" sites={props.TopActivity.rows} length={6} />
+            <GroupedActivityFeed title="Recent Activity" sites={props.TopActivity.rows} length={6} />
           </section>
         </div>
       </div>

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -76,7 +76,7 @@ const Spotlight = React.createClass({
       blankSites.push(<li className="spotlight-item spotlight-placeholder" key={`blank-${i}`} />);
     }
     return (<section className="spotlight">
-      <h3 className="section-title">Spotlight</h3>
+      <h3 className="section-title">Featured</h3>
       <ul>
         {sites.map(site => <SpotlightItem key={site.url} onDelete={this.onDelete} {...site} />)}
         {blankSites}


### PR DESCRIPTION
Renamed Spotlight to Featured and Top Activity to Recent Activity. Both appear to be showing up correctly on new tab and the timeline.

Fixes #352.

@pdehaan @k88hudson r?