### PR TITLE
fix(content): #388 Rename Featured to Highlights

### DIFF
--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -76,7 +76,7 @@ const Spotlight = React.createClass({
       blankSites.push(<li className="spotlight-item spotlight-placeholder" key={`blank-${i}`} />);
     }
     return (<section className="spotlight">
-      <h3 className="section-title">Featured</h3>
+      <h3 className="section-title">Highlights</h3>
       <ul>
         {sites.map(site => <SpotlightItem key={site.url} onDelete={this.onDelete} {...site} />)}
         {blankSites}


### PR DESCRIPTION
I managed to get this wrong the last time. Apologies. Spotlight -> Featured -> Highlights :tada: 

Fixes #388.

@pdehaan r?