### PR TITLE
fix(caching): make preview cache repopulation deterministic

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -67,7 +67,7 @@ function ActivityStreams(options = {}) {
 
   this._previewProvider = new PreviewProvider();
   this._previewProvider.cleanUpCache();
-  this._buildPreviewCache(PREVIEW_CACHE_TIMEOUT);
+  this._asyncBuildPreviewCache(PREVIEW_CACHE_TIMEOUT);
 }
 
 ActivityStreams.prototype = {
@@ -100,32 +100,11 @@ ActivityStreams.prototype = {
   },
 
   /**
-   * Prime our embedly cache with a normal content page load
-   */
-  _buildPreviewCache(primeCacheTimeout) {
-    let linksToSend = [];
-    PlacesProvider.links.getTopFrecentSites().then(links => {
-      linksToSend.push(...links);
-    });
-    PlacesProvider.links.getRecentBookmarks().then(links => {
-      linksToSend.push(...links);
-    });
-    PlacesProvider.links.getRecentLinks().then(links => {
-      linksToSend.push(...links);
-    });
-    PlacesProvider.links.getFrecentLinks().then(links => {
-      linksToSend.push(...links);
-    });
-    this._previewProvider.saveNewLinks(linksToSend);
-    this._setBuildPreviewCacheTimeout(primeCacheTimeout);
-  },
-
-  /**
    * Set up preview cache to be primed every 6 hours
    */
   _setBuildPreviewCacheTimeout(primeCacheTimeout) {
     this._previewCacheTimeoutID = setTimeout(() => {
-      this._buildPreviewCache();
+      this._asyncBuildPreviewCache();
     }, primeCacheTimeout);
   },
 
@@ -321,6 +300,34 @@ ActivityStreams.prototype = {
       ]);
       Services.obs.notifyObservers(null, "activity-streams-places-cache-complete", null);
     }
+  }),
+
+  /**
+   * Builds a preview cache with links from a normal content page load
+   */
+  _asyncBuildPreviewCache: Task.async(function*(primeCacheTimeout) {
+    let linksToSend = [];
+    let promises = [];
+
+    promises.push(PlacesProvider.links.getTopFrecentSites().then(links => {
+      linksToSend.push(...links);
+    }));
+
+    promises.push(PlacesProvider.links.getRecentBookmarks().then(links => {
+      linksToSend.push(...links);
+    }));
+
+    promises.push(PlacesProvider.links.getRecentLinks().then(links => {
+      linksToSend.push(...links);
+    }));
+
+    promises.push(PlacesProvider.links.getFrecentLinks().then(links => {
+      linksToSend.push(...links);
+    }));
+
+    yield Promise.all(promises);
+    this._previewProvider.saveNewLinks(linksToSend);
+    this._setBuildPreviewCacheTimeout(primeCacheTimeout);
   }),
 
   /**


### PR DESCRIPTION
#304 introduced a bug where cache rebuilds would be non-deterministic: the function triggered asynchronous tasks but didn't wait for them to complete before launching the next task