### PR TITLE
Block instead of delete for spotlight, top sites

### DIFF
--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -13,6 +13,7 @@ const am = new ActionManager([
   "RECENT_LINKS_RESPONSE",
   "FRECENT_LINKS_REQUEST",
   "FRECENT_LINKS_RESPONSE",
+  "BLOCK_URL",
   "NOTIFY_HISTORY_DELETE",
   "NOTIFY_PERFORM_SEARCH",
   "RECEIVE_CURRENT_ENGINE",
@@ -20,7 +21,6 @@ const am = new ActionManager([
   "SEARCH_STATE_RESPONSE",
   "NOTIFY_ROUTE_CHANGE",
   "NOTIFY_PERFORMANCE",
-  "NOTIFY_TELEMETRY",
   "NOTIFY_USER_EVENT"
 ]);
 
@@ -106,6 +106,14 @@ function RequestSearchState() {
   return RequestExpect("SEARCH_STATE_REQUEST", "SEARCH_STATE_RESPONSE");
 }
 
+function BlockUrl(url) {
+  alert("We're still working on this feature. Thanks for your patience!");
+  return {
+    type: "BLOCK_URL",
+    data: url
+  };
+}
+
 function NotifyHistoryDelete(data) {
   return Notify("NOTIFY_HISTORY_DELETE", data);
 }
@@ -146,6 +154,7 @@ am.defineActions({
   RequestMoreRecentLinks,
   RequestFrecentLinks,
   RequestSearchState,
+  BlockUrl,
   NotifyHistoryDelete,
   NotifyPerformSearch,
   NotifyRouteChange,

--- a/content-src/components/Spotlight/Spotlight.js
+++ b/content-src/components/Spotlight/Spotlight.js
@@ -83,7 +83,7 @@ const Spotlight = React.createClass({
   },
   onDeleteFactory(index) {
     return url => {
-      this.props.dispatch(actions.NotifyHistoryDelete(url));
+      this.props.dispatch(actions.BlockUrl(url));
       this.props.dispatch(actions.NotifyEvent({
         event: "DELETE",
         page: this.props.page,

--- a/content-src/components/TopSites/TopSites.js
+++ b/content-src/components/TopSites/TopSites.js
@@ -14,7 +14,7 @@ const TopSites = React.createClass({
     };
   },
   onDelete(url, index) {
-    this.props.dispatch(actions.NotifyHistoryDelete(url));
+    this.props.dispatch(actions.BlockUrl(url));
     this.props.dispatch(actions.NotifyEvent({
       event: "DELETE",
       page: this.props.page,

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -23,5 +23,8 @@ module.exports = {
       "placeholder": "Search With Google",
       "iconBuffer": {}
     }
+  },
+  "Blocked": {
+    "urls": new Set()
   }
 };

--- a/content-src/reducers/reducers.js
+++ b/content-src/reducers/reducers.js
@@ -68,10 +68,24 @@ function setSearchState(type) {
   };
 }
 
+function Blocked(prevState = {urls: new Set()}, action) {
+  let state = {};
+  switch (action.type) {
+    case am.type("BLOCK_URL"):
+      state.urls = new Set(prevState.urls);
+      state.urls.add(action.data);
+      break;
+    default:
+      return prevState;
+  }
+  return Object.assign({}, prevState, state);
+}
+
 module.exports = {
   TopSites: setRowsOrError("TOP_FRECENT_SITES_REQUEST", "TOP_FRECENT_SITES_RESPONSE"),
   FrecentHistory: setRowsOrError("RECENT_LINKS_REQUEST", "FRECENT_LINKS_RESPONSE"),
   History: setRowsOrError("RECENT_LINKS_REQUEST", "RECENT_LINKS_RESPONSE"),
   Bookmarks: setRowsOrError("RECENT_BOOKMARKS_REQUEST", "RECENT_BOOKMARKS_RESPONSE"),
-  Search: setSearchState("SEARCH_STATE_RESPONSE")
+  Search: setSearchState("SEARCH_STATE_RESPONSE"),
+  Blocked
 };

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -7,6 +7,7 @@ const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const {mockData, faker} = require("test/test-utils");
+const am = require("common/action-manager");
 
 const fakeSpotlightItems = mockData.Spotlight.rows;
 const fakeSiteWithImage = faker.createSite();
@@ -30,7 +31,20 @@ describe("Spotlight", function() {
     });
   });
 
-  describe("events", () => {
+  describe("actions", () => {
+    it("should fire a block action when delete button is clicked", done => {
+      let url;
+      function dispatch(a) {
+        if (a.type === am.type("BLOCK_URL")) {
+          assert.equal(a.data, url);
+          done();
+        }
+      }
+      instance = TestUtils.renderIntoDocument(<Spotlight sites={fakeSpotlightItems} dispatch={dispatch} />);
+      const firstItem = TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0];
+      url = firstItem.props.url;
+      TestUtils.Simulate.click(firstItem.refs.delete);
+    });
     it("should fire a click event when delete is clicked", done => {
       function dispatch(a) {
         if (a.type === "NOTIFY_USER_EVENT") {

--- a/content-test/components/TopSites.test.js
+++ b/content-test/components/TopSites.test.js
@@ -7,6 +7,7 @@ const {overrideConsoleError} = require("test/test-utils");
 const ConnectedTopSites = require("components/TopSites/TopSites");
 const {TopSites} = ConnectedTopSites;
 const SiteIcon = require("components/SiteIcon/SiteIcon");
+const am = require("common/action-manager");
 
 const fakeProps = {
   sites: [
@@ -60,6 +61,19 @@ describe("TopSites", () => {
       assert.equal(linkEls.length, fakeProps.sites.length);
       assert.include(linkEls[0].href, fakeProps.sites[0].url);
       assert.include(linkEls[1].href, fakeProps.sites[1].url);
+    });
+  });
+
+  describe("actions", () => {
+    it("should fire a block action when delete button is clicked", done => {
+      function dispatch(a) {
+        if (a.type === am.type("BLOCK_URL")) {
+          assert.equal(a.data, fakeProps.sites[0].url);
+          done();
+        }
+      }
+      const instance = TestUtils.renderIntoDocument(<TopSites dispatch={dispatch} sites={fakeProps.sites} />);
+      TestUtils.Simulate.click(TestUtils.scryRenderedDOMComponentsWithClass(instance, "tile-close-icon")[0]);
     });
   });
 

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -112,6 +112,23 @@ describe("selectors", () => {
       const groups = [state.TopSites.rows, state.Spotlight.rows, state.TopActivity.rows];
       assert.deepEqual(groups, dedupe.group(groups));
     });
+    it("should remove urls in block list", () => {
+      state = selectNewTabSites({
+        TopSites: {rows: [
+          {url: "foo1.com", lastVisitDate: 1},
+          {url: "bar2.com", lastVisitDate: 4},
+          {url: "baz3.com", lastVisitDate: 3}
+        ]},
+        Spotlight: {rows: []},
+        FrecentHistory: {rows: []},
+        History: {rows: []},
+        Blocked: {urls: new Set(["foo1.com"])}
+      });
+      assert.deepEqual(state.TopSites.rows, [
+        {url: "bar2.com", lastVisitDate: 4},
+        {url: "baz3.com", lastVisitDate: 3}
+      ]);
+    });
     it("should sort TopActivity by dateLastVisited", () => {
       state = selectNewTabSites({
         TopSites: {rows: []},
@@ -126,6 +143,7 @@ describe("selectors", () => {
           {url: "bar2.com", lastVisitDate: 4},
           {url: "baz3.com", lastVisitDate: 3}
         ]},
+        Blocked: {urls: new Set()}
       });
       assert.deepEqual(state.TopActivity.rows,
         [


### PR DESCRIPTION
This changes delete for spotlight, top sites to a "block" strategy and warns that it's not yet complete.

Requires a follow-up for filling in empty boxes after deleting, https://github.com/mozilla/activity-streams/issues/393

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/476)
<!-- Reviewable:end -->
