### PR TITLE
fix(addon): #468 Prioritize new data in getCachedLinks

### DIFF
--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -166,14 +166,14 @@ PreviewProvider.prototype = {
     * Filter cached links out, and store their embedly data
     */
   getCachedLinks(links) {
-    let cachedLinks = [];
-    links.forEach(link => {
+    return links.map(link => {
       if (link && ss.storage.embedlyData[link.cacheKey] && link.cacheKey === ss.storage.embedlyData[link.cacheKey].cacheKey) {
-        cachedLinks.push(ss.storage.embedlyData[link.cacheKey]);
+        return Object.assign({}, ss.storage.embedlyData[link.cacheKey], link);
+      } else {
+        return null;
       }
-    });
-
-    return cachedLinks;
+    })
+    .filter(link => link);
   },
 
   /**

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -166,8 +166,12 @@ PreviewProvider.prototype = {
     * Filter cached links out, and store their embedly data
     */
   getCachedLinks(links) {
+    if (!this.enabled) {
+      return links;
+    }
+
     return links.map(link => {
-      if (link && ss.storage.embedlyData[link.cacheKey] && link.cacheKey === ss.storage.embedlyData[link.cacheKey].cacheKey) {
+      if (link && link.cacheKey && ss.storage.embedlyData[link.cacheKey]) {
         return Object.assign({}, ss.storage.embedlyData[link.cacheKey], link);
       } else {
         return null;
@@ -213,34 +217,24 @@ PreviewProvider.prototype = {
    * Extracts data from embedly and caches it
    */
   _asyncFetchAndCache: Task.async(function*(newLinks) {
+    if (!this.enabled) {
+      return;
+    }
     // extract only the sanitized link urls to send to embedly
     let linkURLs = newLinks.map(link => link.sanitizedURL);
     try {
-      if (this.enabled) {
-        // Make network call when enabled
-        let response = yield this._asyncGetLinkData(linkURLs);
-        if (response.ok) {
-          let responseJson = yield response.json();
-          const data = newLinks
-              .map(site => {
-                const details = responseJson.urls[site.sanitizedURL];
-                if (!details) {
-                  return site;
-                }
-                return Object.assign({}, details, site);
-              });
-          // store embedly data in cache
-          data.map(link => {
-            ss.storage.embedlyData[link.cacheKey] = link;
-            ss.storage.embedlyData[link.cacheKey].accessTime = Date.now();
-          });
-        }
-      } else {
-        // when disabled, return links as-is
-        for (let link of newLinks) {
-          ss.storage.embedlyData[link.cacheKey] = link;
+      // Make network call when enabled
+      let response = yield this._asyncGetLinkData(linkURLs);
+      if (response.ok) {
+        let responseJson = yield response.json();
+        newLinks.forEach(link => {
+          const data = responseJson.urls[link.sanitizedURL];
+          if (!data) {
+            return;
+          }
+          ss.storage.embedlyData[link.cacheKey] = data;
           ss.storage.embedlyData[link.cacheKey].accessTime = Date.now();
-        }
+        });
       }
     } catch (err) {
       Cu.reportError(err);

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -168,14 +168,7 @@ exports.test_mock_embedly_request = function*(assert) {
   const fakeData = [fakeSite];
   const fakeDataCached = {"urls": {
     "http://example.com/": {
-      "title": null,
-      "lastVisitDate": 1459537019000,
-      "frecency": 1000,
-      "favicon": null,
-      "type": "history",
-      "embedlyMetaData": "some embedly metadata",
-      "sanitizedURL": "http://example.com/",
-      "cacheKey": "example.com/"
+      "embedlyMetaData": "some embedly metadata"
     }
   }};
 
@@ -189,18 +182,26 @@ exports.test_mock_embedly_request = function*(assert) {
 
   yield gPreviewProvider._asyncFetchAndCache(fakeData);
 
-  assert.ok(ss.storage.embedlyData[fakeDataCached.urls["http://example.com/"].cacheKey], "the cache created an entry with the cache key");
-  assert.deepEqual(ss.storage.embedlyData[fakeDataCached.urls["http://example.com/"].cacheKey].embedlyMetaData, "some embedly metadata", "the cache saved the embedly data");
-  assert.ok(ss.storage.embedlyData[fakeDataCached.urls["http://example.com/"].cacheKey].accessTime, "the cached saved a time stamp");
+  assert.deepEqual(ss.storage.embedlyData[fakeSite.cacheKey].embedlyMetaData, "some embedly metadata", "the cache saved the embedly data");
+  assert.ok(ss.storage.embedlyData[fakeSite.cacheKey].accessTime, "the cached saved a time stamp");
 
   let cachedLinks = gPreviewProvider.getCachedLinks(fakeData);
   assert.equal(cachedLinks[0].lastVisitDate, fakeSite.lastVisitDate, "getCachedLinks should prioritize new data");
   assert.equal(cachedLinks[0].bookmarkDateCreated, fakeSite.bookmarkDateCreated, "getCachedLinks should prioritize new data");
-  assert.ok(cachedLinks.some(e => e.cacheKey === ss.storage.embedlyData[fakeDataCached.urls["http://example.com/"].cacheKey].cacheKey), "the cached link is now retrieved next time");
+  assert.ok(ss.storage.embedlyData[fakeSite.cacheKey], "the cached link is now retrieved next time");
 
   yield new Promise(resolve => {
     srv.stop(resolve);
   });
+};
+
+exports.test_get_cached_disabled = function*(assert) {
+  const fakeData = [
+    {url: "http://foo.com/", lastVisitDate: 1459537019061}
+  ];
+  simplePrefs.prefs["previews.enabled"] = false;
+  let cachedLinks = gPreviewProvider.getCachedLinks(fakeData);
+  assert.deepEqual(cachedLinks, fakeData, "if disabled, should return links as is");
 };
 
 before(exports, function*() {


### PR DESCRIPTION
This fixes `getCachedLinks` so that new values in links will be prioritized over cached ones if they are available.

Fixes #468

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/487)
<!-- Reviewable:end -->
