### PR TITLE
fix(content): #458 always show link to timeline on newtab

### DIFF
--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -5,7 +5,6 @@ const TopSites = require("components/TopSites/TopSites");
 const GroupedActivityFeed = require("components/ActivityFeed/ActivityFeed");
 const Spotlight = require("components/Spotlight/Spotlight");
 const Search = require("components/Search/Search");
-const LoadMore = require("components/LoadMore/LoadMore");
 const {actions} = require("common/action-manager");
 const {Link} = require("react-router");
 
@@ -48,7 +47,9 @@ const NewTabPage = React.createClass({
 
           <section>
             <GroupedActivityFeed title="Recent Activity" sites={props.TopActivity.rows} length={MAX_TOP_ACTIVITY_ITEMS} page={PAGE_NAME} />
-            <LoadMore to="/timeline" label="See more activity" hidden={props.TopActivity.rows.length < MAX_TOP_ACTIVITY_ITEMS} />
+            <p className="timeline-link-container">
+              <Link className="timeline-link" to="/timeline">See all activity</Link>
+            </p>
           </section>
         </div>
       </div>

--- a/content-src/components/NewTabPage/NewTabPage.scss
+++ b/content-src/components/NewTabPage/NewTabPage.scss
@@ -4,6 +4,21 @@
   margin: 0 auto;
 }
 
+.timeline-link-container {
+  text-align: left;
+}
+.timeline-link {
+  font-size: 12px;
+  border: 1px solid $faintest-black;
+  border-radius: 3px;
+  padding: 4px 16px;
+  color: $light-grey;
+  &:hover {
+    background: $very-light-grey;
+    color: inherit;
+  }
+}
+
 .debug-link {
   position: fixed;
   bottom: 0;


### PR DESCRIPTION
Fixes #458 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/512)
<!-- Reviewable:end -->
