### PR TITLE
New highlight query

### DIFF
--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -13,6 +13,8 @@ const am = new ActionManager([
   "RECENT_LINKS_RESPONSE",
   "FRECENT_LINKS_REQUEST",
   "FRECENT_LINKS_RESPONSE",
+  "HIGHLIGHTS_LINKS_REQUEST",
+  "HIGHLIGHTS_LINKS_RESPONSE",
   "BLOCK_URL",
   "NOTIFY_HISTORY_DELETE",
   "NOTIFY_PERFORM_SEARCH",
@@ -30,7 +32,8 @@ am.ACTIONS_WITH_SITES = new Set([
   "TOP_FRECENT_SITES_RESPONSE",
   "RECENT_BOOKMARKS_RESPONSE",
   "RECENT_LINKS_RESPONSE",
-  "FRECENT_LINKS_RESPONSE"
+  "FRECENT_LINKS_RESPONSE",
+  "HIGHLIGHTS_LINKS_RESPONSE",
 ].map(type => am.type(type)));
 
 function Notify(type, data) {
@@ -102,6 +105,10 @@ function RequestFrecentLinks() {
   return RequestExpect("FRECENT_LINKS_REQUEST", "FRECENT_LINKS_RESPONSE");
 }
 
+function RequestHighlightsLinks() {
+  return RequestExpect("HIGHLIGHTS_LINKS_REQUEST", "HIGHLIGHTS_LINKS_RESPONSE");
+}
+
 function RequestSearchState() {
   return RequestExpect("SEARCH_STATE_REQUEST", "SEARCH_STATE_RESPONSE");
 }
@@ -153,6 +160,7 @@ am.defineActions({
   RequestRecentLinks,
   RequestMoreRecentLinks,
   RequestFrecentLinks,
+  RequestHighlightsLinks,
   RequestSearchState,
   BlockUrl,
   NotifyHistoryDelete,

--- a/content-src/components/Base/Base.js
+++ b/content-src/components/Base/Base.js
@@ -15,6 +15,8 @@ const Base = React.createClass({
 
     this.props.dispatch(actions.RequestSearchState());
 
+    this.props.dispatch(actions.RequestHighlightsLinks());
+
     this.props.dispatch(actions.NotifyPerf("BASE_MOUNTED"));
   },
   render() {

--- a/content-src/components/DebugPage/DebugPage.js
+++ b/content-src/components/DebugPage/DebugPage.js
@@ -42,6 +42,7 @@ module.exports = connect(state => {
       FrecentHistory: state.FrecentHistory,
       History: state.History,
       Bookmarks: state.Bookmarks,
+      Highlights: state.Highlights,
     }
   };
 })(DebugPage);

--- a/content-src/lib/fake-data.js
+++ b/content-src/lib/fake-data.js
@@ -13,6 +13,10 @@ module.exports = {
     "rows": faker.createRows({images: 3}),
     "error": false
   },
+  "Highlights": {
+    "rows": faker.createRows({images: 3}),
+    "error": false
+  },
   "Bookmarks": {
     "rows": faker.createRows({images: 3, type: "bookmark"}),
     "error": false

--- a/content-src/lib/shim.js
+++ b/content-src/lib/shim.js
@@ -55,6 +55,9 @@ module.exports = function() {
           });
         })});
         break;
+      case "HIGHLIGHTS_LINKS_REQUEST":
+        dispatch({type: "HIGHLIGHTS_LINKS_RESPONSE", data: fakeData.Highlights.rows});
+        break;
     }
   }, false);
 };

--- a/content-src/reducers/reducers.js
+++ b/content-src/reducers/reducers.js
@@ -86,6 +86,7 @@ module.exports = {
   FrecentHistory: setRowsOrError("RECENT_LINKS_REQUEST", "FRECENT_LINKS_RESPONSE"),
   History: setRowsOrError("RECENT_LINKS_REQUEST", "RECENT_LINKS_RESPONSE"),
   Bookmarks: setRowsOrError("RECENT_BOOKMARKS_REQUEST", "RECENT_BOOKMARKS_RESPONSE"),
+  Highlights: setRowsOrError("HIGHLIGHTS_LINKS_REQUEST", "HIGHLIGHTS_LINKS_RESPONSE"),
   Search: setSearchState("SEARCH_STATE_RESPONSE"),
   Blocked
 };

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -68,10 +68,11 @@ module.exports.selectNewTabSites = createSelector(
     state => state.TopSites,
     state => state.FrecentHistory,
     state => state.History,
+    state => state.Highlights,
     selectSpotlight,
     state => state.Blocked
   ],
-  (TopSites, FrecentHistory, History, Spotlight, Blocked) => {
+  (TopSites, FrecentHistory, History, Highlights, Spotlight, Blocked) => {
 
     // Removed blocked
     [TopSites, Spotlight] = [TopSites, Spotlight].map(item => {
@@ -93,7 +94,7 @@ module.exports.selectNewTabSites = createSelector(
       TopSites: Object.assign({}, TopSites, {rows: topSitesRows}),
       Spotlight: Object.assign({}, FrecentHistory, {rows: spotlightRows}),
       TopActivity: Object.assign({}, History, {rows: topActivityRows}),
-      isReady: TopSites.init && FrecentHistory.init && History.init
+      isReady: TopSites.init && FrecentHistory.init && History.init && Highlights.init
     };
   }
 );

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -129,6 +129,11 @@ ActivityStreams.prototype = {
           this._processAndSendLinks(links, "FRECENT_LINKS_RESPONSE", append, worker);
         });
         break;
+      case am.type("HIGHLIGHTS_LINKS_REQUEST"):
+        this._memoized.getHighlightsLinks(msg.data).then(links => {
+          this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", append, worker);
+        });
+        break;
       case am.type("NOTIFY_HISTORY_DELETE"):
         PlacesProvider.links.deleteHistoryLink(msg.data);
         break;
@@ -224,6 +229,7 @@ ActivityStreams.prototype = {
     SearchProvider.search.on("browser-search-engine-modified", this._handleCurrentEngineChanges);
 
     this.on(am.type("TOP_FRECENT_SITES_REQUEST"), this._respondToPlacesRequests);
+    this.on(am.type("HIGHLIGHTS_LINKS_REQUEST"), this._respondToPlacesRequests);
     this.on(am.type("FRECENT_LINKS_REQUEST"), this._respondToPlacesRequests);
     this.on(am.type("RECENT_BOOKMARKS_REQUEST"), this._respondToPlacesRequests);
     this.on(am.type("RECENT_LINKS_REQUEST"), this._respondToPlacesRequests);
@@ -268,6 +274,7 @@ ActivityStreams.prototype = {
       getRecentBookmarks: cache.memoize("getRecentBookmarks", PlacesProvider.links.getRecentBookmarks.bind(linksObj)),
       getRecentLinks: cache.memoize("getRecentLinks", PlacesProvider.links.getRecentLinks.bind(linksObj)),
       getFrecentLinks: cache.memoize("getFrecentLinks", PlacesProvider.links.getFrecentLinks.bind(linksObj)),
+      getHighlightsLinks: cache.memoize("getHighlightsLinks", PlacesProvider.links.getHighlightsLinks.bind(linksObj)),
       getHistorySize: cache.memoize("getHistorySize", PlacesProvider.links.getHistorySize.bind(linksObj)),
       getBookmarksSize: cache.memoize("getBookmarksSize", PlacesProvider.links.getBookmarksSize.bind(linksObj)),
     };
@@ -287,6 +294,7 @@ ActivityStreams.prototype = {
             this._memoized.getRecentBookmarks(),
             this._memoized.getRecentLinks(),
             this._memoized.getFrecentLinks(),
+            this._memoized.getHighlightsLinks(),
             this._memoized.getHistorySize(),
             this._memoized.getBookmarksSize(),
         ]);
@@ -321,6 +329,10 @@ ActivityStreams.prototype = {
         linksToSend.push(...links);
       }));
 
+      promises.push(PlacesProvider.links.getHighlightsLinks().then(links => {
+        linksToSend.push(...links);
+      }));
+
       yield Promise.all(promises);
       yield this._previewProvider.asyncSaveNewLinks(linksToSend);
       this._populatingCache.preview = false;
@@ -351,6 +363,7 @@ ActivityStreams.prototype = {
         "getRecentBookmarks",
         "getRecentLinks",
         "getFrecentLinks",
+        "getHighlightsLinks",
         "getHistorySize",
         "getBookmarksSize",
     ]);

--- a/lib/PlacesProvider.js
+++ b/lib/PlacesProvider.js
@@ -33,6 +33,23 @@ const HISTORY_RESULTS_LIMIT = 20;
 // time interval for for frecent links query in milliseconds (72 hours).
 const FRECENT_RESULTS_TIME_LIMIT = 72 * 60 * 60 * 1000;
 
+const REV_HOST_BLACKLIST = [
+  "moc.elgoog.www.",
+  "ac.elgoog.www.",
+  "moc.elgoog.radnelac.",
+  "moc.elgoog.liam.",
+  "moc.oohay.liam.",
+  "moc.oohay.hcraes.",
+  "tsohlacol.",
+  "oc.t.",
+  ".",
+].map(item => `'${item}'`);
+
+const HIGHLIGHTS_THRESHOLDS = {
+  created: "-3 day",
+  visited: "-30 minutes",
+};
+
 /**
  * Singleton that checks if a given link should be displayed on about:newtab
  * or if we should rather not do it for security reasons. URIs that inherit
@@ -430,6 +447,89 @@ Links.prototype = {
     }
     return null;
   }),
+
+  /**
+   * Obtain a set of links for highlights
+   *
+   * @param {Object} options
+   *        {Integer} limit: Maximum number of results to return. Max 20
+   *
+   * @returns {Promise} Returns a promise with the array of links as payload.
+   */
+  getHighlightsLinks: Task.async(function*(options = {}) {
+
+    let {limit} = options;
+    if (!limit || limit.options > HISTORY_RESULTS_LIMIT) {
+      limit = HISTORY_RESULTS_LIMIT;
+    }
+
+    let params = {limitBookmarks: 1, limitHistory: (limit - 1)};
+
+    let sqlQuery = `SELECT DISTINCT * FROM (
+                      SELECT * FROM (
+                        SELECT p.url as url,
+                               f.data as favicon,
+                               f.mime_type as mimeType,
+                               p.title as title,
+                               p.frecency as frecency,
+                               p.last_visit_date / 1000 as lastVisitDate,
+                               "bookmark" as type,
+                               b.id as bookmarkId,
+                               b.guid as bookmarkGuid,
+                               b.title as bookmarkTitle,
+                               b.lastModified / 1000 as lastModified,
+                               b.dateAdded / 1000 as bookmarkDateCreated
+                        FROM moz_places p
+                        INNER JOIN moz_bookmarks b
+                          ON b.fk = p.id
+                        LEFT JOIN moz_favicons f
+                          ON p.favicon_id = f.id
+                        WHERE date(b.dateAdded / 1000 / 1000, 'unixepoch') > date('now', '${HIGHLIGHTS_THRESHOLDS.created}')
+                        AND p.visit_count <= 3
+                        ORDER BY b.dateAdded DESC
+                        LIMIT :limitBookmarks
+                      )
+
+                      UNION ALL
+
+                      SELECT * FROM (
+                        SELECT p.url as url,
+                               f.data as favicon,
+                               f.mime_type as mimeType,
+                               p.title as title,
+                               p.frecency as frecency,
+                               p.last_visit_date / 1000 as lastVisitDate,
+                               "history" as type,
+                               b.id as bookmarkId,
+                               b.guid as bookmarkGuid,
+                               b.title as bookmarkTitle,
+                               b.lastModified / 1000 as lastModified,
+                               b.dateAdded / 1000 as bookmarkDateCreated
+                        FROM moz_places p
+                        LEFT JOIN moz_bookmarks b
+                          ON b.fk = p.id
+                        LEFT JOIN moz_favicons f
+                          ON p.favicon_id = f.id
+                        WHERE datetime(p.last_visit_date / 1000 / 1000, 'unixepoch') < datetime('now', '${HIGHLIGHTS_THRESHOLDS.visited}')
+                        AND p.visit_count <= 3
+                        AND p.title NOT NULL
+                        AND p.rev_host NOT IN (${REV_HOST_BLACKLIST})
+                        GROUP BY p.rev_host
+                        ORDER BY p.last_visit_date DESC
+                        LIMIT :limitHistory
+                      )
+                    )`;
+
+    let links = yield this.executePlacesQuery(sqlQuery, {
+                  columns: ["bookmarkId", "bookmarkTitle", "bookmarkGuid", "bookmarkDateCreated", "url",
+                            "title", "lastVisitDate", "frecency", "type", "lastModified", "favicon", "mimeType"],
+                  params: params,
+                });
+
+    links = this._faviconBytesToDataURI(links);
+    return links.filter(link => LinkChecker.checkLoadURI(link.url));
+  }),
+
   /**
    * From an Array of links, if favicons are present, convert to data URIs
    *

--- a/test/test-ActivityStreams-places-caching.js
+++ b/test/test-ActivityStreams-places-caching.js
@@ -34,7 +34,8 @@ let makeNotifsPromise = (cacheStatus) => {
         "getTopFrecentSites-cache",
         "getRecentBookmarks-cache",
         "getRecentLinks-cache",
-        "getFrecentLinks-cache"
+        "getFrecentLinks-cache",
+        "getHighlightsLinks-cache",
     ]);
     let notifCount = 0;
     let observer = function(subject, topic, data) {

--- a/test/test-PlacesProvider.js
+++ b/test/test-PlacesProvider.js
@@ -112,6 +112,34 @@ exports.test_Links_getTopFrecentSites_Order = function*(assert) {
   }
 };
 
+exports.test_Links_getHighlightsLinks = function*(assert) {
+  let provider = PlacesProvider.links;
+  let {
+    TRANSITION_TYPED,
+  } = PlacesUtils.history;
+
+  let timeToday = timeDaysAgo(0);
+  let timeEarlier = timeDaysAgo(2);
+
+  let visits = [
+    {uri: NetUtil.newURI("https://example1.com/"), visitDate: timeToday, transition: TRANSITION_TYPED},
+    {uri: NetUtil.newURI("https://example2.com/"), visitDate: timeToday, transition: TRANSITION_TYPED},
+    {uri: NetUtil.newURI("https://example3.com/"), visitDate: timeEarlier, transition: TRANSITION_TYPED},
+    {uri: NetUtil.newURI("https://mail.google.com/"), visitDate: timeEarlier, transition: TRANSITION_TYPED},
+  ];
+
+  let links = yield provider.getHighlightsLinks();
+  assert.equal(links.length, 0, "empty history yields empty links");
+  yield PlacesTestUtils.addVisits(visits);
+
+  let recentLinks = yield provider.getRecentLinks();
+  assert.equal(recentLinks.length, visits.length, "number of links added is the same as obtain by getRecentLinks");
+
+  // note: this is a sanity test because the query may change
+  links = yield provider.getHighlightsLinks();
+  assert.equal(links.length, 1, "getHighlightsLinks filters links by date and hostname");
+};
+
 exports.test_Links_getRecentLinks = function*(assert) {
   let provider = PlacesProvider.links;
   let {


### PR DESCRIPTION
As requested in #389, this implements a new highlight query.

Given that we're likely to iterate rapidly on the query, there isn't thorough testing for the results of the query, just a sanity check.

I started implementing the UI integration, however, I found that the deduping logic yields potentially undesirable effects, resulting in empty spotlight spots. We'll have to file a follow-up bug to play around with the query and its integration overall.

r? @k88hudson, @mzhilyaev

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/531)
<!-- Reviewable:end -->
