### PR TITLE
Fix some preview caching issues

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -69,7 +69,6 @@ function ActivityStreams(options = {}) {
   this._asyncBuildPlacesCache();
 
   this._asyncBuildPreviewCache();
-  this._previewProvider.startPeriodicCleanup();
   this._startPeriodicBuildPreviewCache(this.options.previewCacheTimeout);
 }
 
@@ -145,7 +144,7 @@ ActivityStreams.prototype = {
    */
   _processAndSendLinks(links, responseType, append, worker) {
     let processedLinks = this._previewProvider.processLinks(links);
-    this._previewProvider.asyncSaveNewLinks(processedLinks).then(() => {
+    this._previewProvider.asyncSaveLinks(processedLinks).then(() => {
       const cachedLinks = this._previewProvider.getCachedLinks(processedLinks);
       this.send(am.actions.Response(responseType, cachedLinks, {append}), worker);
     });
@@ -334,7 +333,7 @@ ActivityStreams.prototype = {
       }));
 
       yield Promise.all(promises);
-      yield this._previewProvider.asyncSaveNewLinks(linksToSend);
+      yield this._previewProvider.asyncSaveLinks(linksToSend);
       this._populatingCache.preview = false;
       Services.obs.notifyObservers(null, "activity-streams-previews-cache-complete", null);
     }

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -3,7 +3,6 @@
 
 const {Cu} = require("chrome");
 const ss = require("sdk/simple-storage");
-const {setTimeout, clearTimeout} = require("sdk/timers");
 const simplePrefs = require("sdk/simple-prefs");
 const EMBEDLY_PREF = "embedly.endpoint";
 const ENABLED_PREF = "previews.enabled";
@@ -25,7 +24,9 @@ Cu.import("resource://gre/modules/Task.jsm");
 Cu.import("resource://gre/modules/Services.jsm");
 
 const DEFAULT_OPTIONS = {
-  cacheTimeout: 86400000, // 24 hours to clear cache
+  cacheCleanupPeriod: 86400000, // a cache clearing job runs at most once every 24 hours
+  cacheRefreshAge: 259200000, // refresh a link every 3 days
+  cacheTTL: 2592000000, // cached items expire if they haven't been accessed in 30 days
   proxyMaxLinks: 25, // number of links embedly proxy accepts per request
   initFresh: false,
 };
@@ -37,19 +38,31 @@ function PreviewProvider(options = {}) {
 }
 
 PreviewProvider.prototype = {
-  _timeoutID: null,
-
   /**
-    * Clean up cache periodically
-    */
-  cleanUpCache() {
+   * Clean-up the preview cache
+   */
+  cleanUpCacheMaybe(force = false) {
     let currentTime = Date.now();
-    Object.keys(ss.storage.embedlyData).forEach(item => {
-      if ((currentTime - ss.storage.embedlyData[item].accessTime) > this.options.cacheTimeout) {
-        delete ss.storage.embedlyData[item];
+    this._setupState(currentTime);
+
+    // exit if the last cleanup exceeds a threshold
+    if (!force && (currentTime - ss.storage.previewCacheState.lastCleanup) < this.options.cacheCleanupPeriod) {
+      return;
+    }
+
+    for (let key in ss.storage.embedlyData) {
+      if ((currentTime - ss.storage.embedlyData[key].accessTime) > this.options.cacheTTL) {
+        delete ss.storage.embedlyData[key];
       }
-    });
+    }
+    ss.storage.previewCacheState.lastCleanup = currentTime;
     Services.obs.notifyObservers(null, "activity-streams-preview-cache-cleanup", null);
+  },
+
+  _setupState(stateTime) {
+    if (!ss.storage.previewCacheState) {
+      ss.storage.previewCacheState = {lastCleanup: stateTime};
+    }
   },
 
   _onPrefChange(prefName) {
@@ -69,18 +82,6 @@ PreviewProvider.prototype = {
           this.enabled = simplePrefs.prefs[ENABLED_PREF];
           break;
       }
-    }
-  },
-
-  /**
-    * Set up the timer for the cache to be cleaned periodically
-    */
-  startPeriodicCleanup() {
-    if (this.options.cacheTimeout) {
-      this._timeoutID = setTimeout(() => {
-        this.cleanUpCache();
-        this.startPeriodicCleanup();
-      }, this.options.cacheTimeout);
     }
   },
 
@@ -173,6 +174,7 @@ PreviewProvider.prototype = {
       return links;
     }
 
+    this.cleanUpCacheMaybe();
     let now = Date.now();
 
     return links.map(link => {
@@ -187,24 +189,19 @@ PreviewProvider.prototype = {
   },
 
   /**
-   * Filter out new links and request them from embedly
+   * Request links from embedly, optionally filtering out known links
    */
-  asyncSaveNewLinks: Task.async(function*(links) {
-    let newLinks;
-    if (ss.storage.embedlyData) {
-      newLinks = links.filter(link => link && !ss.storage.embedlyData[link.cacheKey]);
-    } else {
-      newLinks = [];
-    }
+  asyncSaveLinks: Task.async(function*(links, newOnly = true, updateAccessTime = true) {
+    let linksList = links.filter(link => link && (!newOnly || !ss.storage.embedlyData[link.cacheKey]));
     let requestQueue = [];
     let promises = [];
-    while (newLinks.length !== 0) {
+    while (linksList.length !== 0) {
       // we have some new links we need to fetch the embedly data for, put them on the queue
-      requestQueue.push(newLinks.splice(0, this.options.proxyMaxLinks));
+      requestQueue.push(linksList.splice(0, this.options.proxyMaxLinks));
     }
     // for each bundle of 25 links, create a new request to embedly
     requestQueue.forEach(requestBundle => {
-      promises.push(this._asyncFetchAndCache(requestBundle));
+      promises.push(this._asyncFetchAndCache(requestBundle, updateAccessTime));
     });
     yield Promise.all(promises);
   }),
@@ -229,7 +226,7 @@ PreviewProvider.prototype = {
   /**
    * Extracts data from embedly and caches it
    */
-  _asyncFetchAndCache: Task.async(function*(newLinks) {
+  _asyncFetchAndCache: Task.async(function*(newLinks, updateAccessTime = true) {
     if (!this.enabled) {
       return;
     }
@@ -240,13 +237,17 @@ PreviewProvider.prototype = {
       let response = yield this._asyncGetLinkData(linkURLs);
       if (response.ok) {
         let responseJson = yield response.json();
+        let currentTime = Date.now();
         newLinks.forEach(link => {
           const data = responseJson.urls[link.sanitizedURL];
           if (!data) {
             return;
           }
           ss.storage.embedlyData[link.cacheKey] = data;
-          ss.storage.embedlyData[link.cacheKey].accessTime = Date.now();
+          if (updateAccessTime) {
+            ss.storage.embedlyData[link.cacheKey].accessTime = currentTime;
+          }
+          ss.storage.embedlyData[link.cacheKey].refreshTime = currentTime;
         });
       }
     } catch (err) {
@@ -265,12 +266,14 @@ PreviewProvider.prototype = {
       ss.storage.embedlyData = {};
     }
     simplePrefs.on("", this._onPrefChange);
+    this._setupState(Date.now());
   },
 
   /**
    * Clear out the preview cache
    */
   clearCache() {
+    delete ss.storage.previewCacheState;
     delete ss.storage.embedlyData;
   },
 
@@ -278,7 +281,6 @@ PreviewProvider.prototype = {
    * Uninit the preview provider
    */
   uninit() {
-    clearTimeout(this._timeoutID);
     simplePrefs.off("", this._onPrefChange);
   },
 };

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -4,6 +4,7 @@
 const {Cu} = require("chrome");
 const ss = require("sdk/simple-storage");
 const simplePrefs = require("sdk/simple-prefs");
+const {setTimeout, clearTimeout} = require("sdk/timers");
 const EMBEDLY_PREF = "embedly.endpoint";
 const ENABLED_PREF = "previews.enabled";
 const ALLOWED_PREFS = new Set([EMBEDLY_PREF, ENABLED_PREF]);
@@ -27,6 +28,7 @@ const DEFAULT_OPTIONS = {
   cacheCleanupPeriod: 86400000, // a cache clearing job runs at most once every 24 hours
   cacheRefreshAge: 259200000, // refresh a link every 3 days
   cacheTTL: 2592000000, // cached items expire if they haven't been accessed in 30 days
+  cacheUpdateInterval: 3600000, // a cache update job runs every hour
   proxyMaxLinks: 25, // number of links embedly proxy accepts per request
   initFresh: false,
 };
@@ -35,9 +37,12 @@ function PreviewProvider(options = {}) {
   this.options = Object.assign({}, DEFAULT_OPTIONS, options);
   this._onPrefChange = this._onPrefChange.bind(this);
   this.init();
+  this._runPeriodicUpdate();
 }
 
 PreviewProvider.prototype = {
+  _updateTimeout: null,
+
   /**
    * Clean-up the preview cache
    */
@@ -73,11 +78,13 @@ PreviewProvider.prototype = {
           break;
         case ENABLED_PREF:
           if (this.enabled) {
-            // if disabling, remove cache
+            // if disabling, remove cache and update
+            this._clearPeriodicUpdate();
             this.clearCache();
           } else {
-            // if enabling, create cache
+            // if enabling, create cache and start updating
             ss.storage.embedlyData = {};
+            this._runPeriodicUpdate();
           }
           this.enabled = simplePrefs.prefs[ENABLED_PREF];
           break;
@@ -192,7 +199,9 @@ PreviewProvider.prototype = {
    * Request links from embedly, optionally filtering out known links
    */
   asyncSaveLinks: Task.async(function*(links, newOnly = true, updateAccessTime = true) {
+    // optionally filter out known links
     let linksList = links.filter(link => link && (!newOnly || !ss.storage.embedlyData[link.cacheKey]));
+
     let requestQueue = [];
     let promises = [];
     while (linksList.length !== 0) {
@@ -205,6 +214,33 @@ PreviewProvider.prototype = {
     });
     yield Promise.all(promises);
   }),
+
+  /**
+   * Asynchronously update links
+   */
+  asyncUpdateLinks: Task.async(function*() {
+    let links = [];
+    let currentTime = Date.now();
+    for (let key in ss.storage.embedlyData) {
+      let link = ss.storage.embedlyData[key];
+      if (!link.refreshTime || (currentTime - link.refreshTime) > this.options.cacheRefreshAge) {
+        links.push(link);
+      }
+    }
+    yield this.asyncSaveLinks(links, false, false);
+    Services.obs.notifyObservers(null, "activity-streams-preview-cache-update", null);
+  }),
+
+  /**
+   * Runs a periodic update
+   */
+  _runPeriodicUpdate() {
+    this._updateTimeout = setTimeout(() => {
+      this.asyncUpdateLinks().then(() => {
+        this._runPeriodicUpdate();
+      });
+    }, this.options.cacheUpdateInterval);
+  },
 
   /**
    * Makes the necessary requests to embedly to get data for each link
@@ -243,7 +279,7 @@ PreviewProvider.prototype = {
           if (!data) {
             return;
           }
-          ss.storage.embedlyData[link.cacheKey] = data;
+          ss.storage.embedlyData[link.cacheKey] = Object.assign({}, ss.storage.embedlyData[link.cacheKey], data);
           if (updateAccessTime) {
             ss.storage.embedlyData[link.cacheKey].accessTime = currentTime;
           }
@@ -278,9 +314,19 @@ PreviewProvider.prototype = {
   },
 
   /**
+   * Clear update timeout
+   */
+  _clearPeriodicUpdate() {
+    if (this._updateTimeout) {
+      clearTimeout(this._updateTimeout);
+    }
+  },
+
+  /**
    * Uninit the preview provider
    */
   uninit() {
+    this._clearPeriodicUpdate();
     simplePrefs.off("", this._onPrefChange);
   },
 };

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -181,10 +181,9 @@ PreviewProvider.prototype = {
       return links;
     }
 
-    this.cleanUpCacheMaybe();
     let now = Date.now();
 
-    return links.map(link => {
+    let results = links.map(link => {
       if (link && link.cacheKey && ss.storage.embedlyData[link.cacheKey]) {
         ss.storage.embedlyData[link.cacheKey].accessTime = now;
         return Object.assign({}, ss.storage.embedlyData[link.cacheKey], link);
@@ -193,6 +192,13 @@ PreviewProvider.prototype = {
       }
     })
     .filter(link => link);
+
+    // gives the opportunity to have at least one run with an old
+    // preview cache. This is for the case where one hasn't opened
+    // the browser since `cacheTTL`
+    this.cleanUpCacheMaybe();
+
+    return results;
   },
 
   /**

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -173,8 +173,11 @@ PreviewProvider.prototype = {
       return links;
     }
 
+    let now = Date.now();
+
     return links.map(link => {
       if (link && link.cacheKey && ss.storage.embedlyData[link.cacheKey]) {
+        ss.storage.embedlyData[link.cacheKey].accessTime = now;
         return Object.assign({}, ss.storage.embedlyData[link.cacheKey], link);
       } else {
         return null;

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -45,6 +45,14 @@ exports.test_enabling = function*(assert) {
   assert.equal(Object.keys(ss.storage.embedlyData).length, 0, "empty object");
 };
 
+exports.test_access_update = function*(assert) {
+  let currentTime = Date.now();
+  let twoDaysAgo = currentTime - (2 * 24 * 60 * 60 * 1000);
+  ss.storage.embedlyData.item_1 = {accessTime: twoDaysAgo};
+  gPreviewProvider.getCachedLinks([{cacheKey: "item_1"}]);
+  assert.ok(ss.storage.embedlyData.item_1.accessTime > twoDaysAgo, "access time is updated");
+};
+
 exports.test_periodic_cleanup = function*(assert) {
   let oldTimeout = gPreviewProvider.options.cacheTimeout;
   gPreviewProvider.options.cacheTimeout = 50;

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -55,6 +55,14 @@ exports.test_access_update = function*(assert) {
   assert.ok(ss.storage.embedlyData.item_1.accessTime > twoDaysAgo, "access time is updated");
 };
 
+exports.test_long_hibernation = function*(assert) {
+  let currentTime = Date.now();
+  let fortyDaysAgo = currentTime - (40 * 24 * 60 * 60 * 1000);
+  ss.storage.embedlyData.item_1 = {accessTime: fortyDaysAgo};
+  gPreviewProvider.getCachedLinks([{cacheKey: "item_1"}]);
+  assert.ok(ss.storage.embedlyData.item_1.accessTime >= currentTime, "access time is updated");
+};
+
 exports.test_periodic_cleanup = function*(assert) {
   let oldThreshold = gPreviewProvider.options.cacheCleanupPeriod;
   gPreviewProvider.options.cacheCleanupPeriod = 30;


### PR DESCRIPTION
This PR:
* increases the TTL for previews to 30 days
* makes cleanups run lazily (allowing for long browser inactivity)
* adds a feature where links are updated periodically

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/541)
<!-- Reviewable:end -->
