### PR TITLE
Always return links

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -111,7 +111,7 @@ ActivityStreams.prototype = {
     switch (msgName) {
       case am.type("TOP_FRECENT_SITES_REQUEST"):
         this._memoized.getTopFrecentSites(msg.data).then(links => {
-          this._processAndSendLinks(links, "TOP_FRECENT_SITES_RESPONSE", append, worker);
+          this._processAndSendLinks(links, "TOP_FRECENT_SITES_RESPONSE", append, worker, true);
         });
         break;
       case am.type("RECENT_BOOKMARKS_REQUEST"):
@@ -131,7 +131,7 @@ ActivityStreams.prototype = {
         break;
       case am.type("HIGHLIGHTS_LINKS_REQUEST"):
         this._memoized.getHighlightsLinks(msg.data).then(links => {
-          this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", append, worker);
+          this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", append, worker, true);
         });
         break;
       case am.type("NOTIFY_HISTORY_DELETE"):
@@ -143,10 +143,10 @@ ActivityStreams.prototype = {
   /*
    * Process the passed in links, save them, get from cache and response to content.
    */
-  _processAndSendLinks(links, responseType, append, worker) {
+  _processAndSendLinks(links, responseType, append, worker, previewsOnly = false) {
     let processedLinks = this._previewProvider.processLinks(links);
     this._previewProvider.asyncSaveLinks(processedLinks).then(() => {
-      const cachedLinks = this._previewProvider.getCachedLinks(processedLinks);
+      const cachedLinks = this._previewProvider.getEnhancedLinks(processedLinks, previewsOnly);
       this.send(am.actions.Response(responseType, cachedLinks, {append}), worker);
     });
   },

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -179,9 +179,9 @@ PreviewProvider.prototype = {
   },
 
   /**
-    * Filter cached links out, and store their embedly data
+    * Returns links with previews if available. Optionally return those with previews only
     */
-  getCachedLinks(links) {
+  getEnhancedLinks(links, previewsOnly = false) {
     if (!this.enabled) {
       return links;
     }
@@ -193,7 +193,7 @@ PreviewProvider.prototype = {
         ss.storage.embedlyData[link.cacheKey].accessTime = now;
         return Object.assign({}, ss.storage.embedlyData[link.cacheKey], link);
       } else {
-        return null;
+        return previewsOnly ? null : link;
       }
     })
     .filter(link => link);

--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -56,7 +56,12 @@ PreviewProvider.prototype = {
     }
 
     for (let key in ss.storage.embedlyData) {
-      if ((currentTime - ss.storage.embedlyData[key].accessTime) > this.options.cacheTTL) {
+      // in case accessTime is not set, don't crash, but don't clean up
+      let accessTime = ss.storage.embedlyData[key].accessTime;
+      if (!accessTime) {
+        ss.storage.embedlyData[key].accessTime = Date.now();
+      }
+      if ((currentTime - accessTime) > this.options.cacheTTL) {
         delete ss.storage.embedlyData[key];
       }
     }


### PR DESCRIPTION
This PR contains commits that:
* ensure that links are always returned for history type queries, even if there are no previews available
* makes the cache cleanup job more tolerant to errors (better for tests)

r? @rlr

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/542)
<!-- Reviewable:end -->
