### PR TITLE
Gh483 - Delete

### DIFF
--- a/common/action-manager.js
+++ b/common/action-manager.js
@@ -17,6 +17,7 @@ const am = new ActionManager([
   "HIGHLIGHTS_LINKS_RESPONSE",
   "BLOCK_URL",
   "NOTIFY_HISTORY_DELETE",
+  "NOTIFY_HISTORY_DELETE_CANCELLED",
   "NOTIFY_PERFORM_SEARCH",
   "RECEIVE_CURRENT_ENGINE",
   "SEARCH_STATE_REQUEST",
@@ -122,7 +123,11 @@ function BlockUrl(url) {
 }
 
 function NotifyHistoryDelete(data) {
-  return Notify("NOTIFY_HISTORY_DELETE", data);
+  if (confirm("Are you sure you want to delete this from your entire history? This action cannot be undone.")) {
+    return Notify("NOTIFY_HISTORY_DELETE", data);
+  } else {
+    return {type: "NOTIFY_HISTORY_DELETE_CANCELLED"};
+  }
 }
 
 function NotifyPerformSearch(data) {

--- a/common/event-constants.js
+++ b/common/event-constants.js
@@ -11,6 +11,7 @@ const constants = {
   events: new Set([
     "CLICK",
     "DELETE",
+    "BLOCK",
     "SHARE",
     "LOAD_MORE",
     "SEARCH"

--- a/content-src/components/ActivityFeed/ActivityFeed.js
+++ b/content-src/components/ActivityFeed/ActivityFeed.js
@@ -3,6 +3,7 @@ const {connect} = require("react-redux");
 const {justDispatch} = require("selectors/selectors");
 const {actions} = require("common/action-manager");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
+const DeleteMenu = require("components/DeleteMenu/DeleteMenu");
 const {prettyUrl, getRandomFromTimestamp} = require("lib/utils");
 const moment = require("moment");
 const classNames = require("classnames");
@@ -20,13 +21,20 @@ const CALENDAR_HEADINGS = {
 };
 
 const ActivityFeedItem = React.createClass({
+  getInitialState() {
+    return {
+      showContextMenu: false
+    };
+  },
   getDefaultProps() {
     return {
       onShare: function() {},
       onClick: function() {},
-      onDelete: function() {},
       showDate: false
     };
+  },
+  onDeleteClick() {
+    this.setState({showContextMenu: true});
   },
   render() {
     const site = this.props;
@@ -55,7 +63,7 @@ const ActivityFeedItem = React.createClass({
       dateLabel = moment(date).format("h:mm A");
     }
 
-    return (<li className={classNames("feed-item", {bookmark: site.bookmarkGuid})}>
+    return (<li className={classNames("feed-item", {bookmark: site.bookmarkGuid, fixed: this.state.showContextMenu})}>
       <a onClick={this.props.onClick} href={site.url} ref="link">
         <span className="star" hidden={!site.bookmarkGuid} />
         {icon}
@@ -70,15 +78,26 @@ const ActivityFeedItem = React.createClass({
         </div>
       </a>
       <div className="action-items-container">
-        <div className="action-item icon-delete" ref="delete" onClick={() => this.props.onDelete(site.url)}></div>
+        <div className="action-item icon-delete" ref="delete" onClick={this.onDeleteClick}></div>
         <div className="action-item icon-share" ref="share" onClick={() => this.props.onShare(site.url)}></div>
         <div className="action-item icon-more" onClick={() => alert("Sorry. We are still working on this feature.")}></div>
       </div>
+      <DeleteMenu
+        visible={this.state.showContextMenu}
+        onUpdate={val => this.setState({showContextMenu: val})}
+        url={site.url}
+        page={this.props.page}
+        index={this.props.index}
+        source={this.props.source}
+        />
     </li>);
   }
 });
 
 ActivityFeedItem.propTypes = {
+  page: React.PropTypes.string,
+  source: React.PropTypes.string,
+  index: React.PropTypes.number,
   onShare: React.PropTypes.func,
   onClick: React.PropTypes.func,
   url: React.PropTypes.string.isRequired,
@@ -144,17 +163,6 @@ const GroupedActivityFeed = React.createClass({
       }));
     };
   },
-  onDeleteFactory(index) {
-    return url => {
-      this.props.dispatch(actions.NotifyHistoryDelete(url));
-      this.props.dispatch(actions.NotifyEvent({
-        event: "DELETE",
-        page: this.props.page,
-        source: "ACTIVITY_FEED",
-        action_position: index
-      }));
-    };
-  },
   onShareFactory(index) {
     return url => {
       alert("Sorry. We are still working on this feature.");
@@ -191,8 +199,10 @@ const GroupedActivityFeed = React.createClass({
                     key={site[this.props.dateKey]}
                     onClick={this.onClickFactory(globalCount)}
                     onShare={this.onShareFactory(globalCount)}
-                    onDelete={this.onDeleteFactory(globalCount)}
                     showImage={getRandomFromTimestamp(0.2, site)}
+                    index={globalCount}
+                    page={this.props.page}
+                    source="ACTIVITY_FEED"
                     showDate={!this.props.showDateHeadings && outerIndex === 0 && i === 0}
                     {...site} />);
               })}

--- a/content-src/components/ActivityFeed/ActivityFeed.scss
+++ b/content-src/components/ActivityFeed/ActivityFeed.scss
@@ -132,6 +132,7 @@
     }
   }
 
+  &.fixed,
   &:hover {
     background: $feed-hover-color;
     border: 1px solid $faintest-black;

--- a/content-src/components/ContextMenu/ContextMenu.js
+++ b/content-src/components/ContextMenu/ContextMenu.js
@@ -1,0 +1,43 @@
+const React = require("react");
+
+const ContextMenu = React.createClass({
+  componentWillMount() {
+    this.hideContext = () => {
+      this.props.onUpdate(false);
+      window.removeEventListener("click", this.hideContext);
+    };
+  },
+  componentWillUnmount() {
+    window.removeEventListener("click", this.hideContext);
+  },
+  componentDidUpdate(prevProps) {
+    if (this.props.visible && !prevProps.visible) {
+      setTimeout(() => {
+        window.addEventListener("click", this.hideContext, false);
+      }, 0);
+    }
+  },
+  render() {
+    return (<div hidden={!this.props.visible} className="context-menu">
+      <ul>
+        {this.props.options.map((option, i) => {
+          return (<li key={i}><a className="context-menu-link" onClick={() => {
+            this.props.onUpdate(false);
+            option.onClick();
+          }}>{option.label}</a></li>);
+        })}
+      </ul>
+    </div>);
+  }
+});
+
+ContextMenu.propTypes = {
+  visible: React.PropTypes.bool,
+  onUpdate: React.PropTypes.func.isRequired,
+  options: React.PropTypes.arrayOf(React.PropTypes.shape({
+    label: React.PropTypes.string.isRequired,
+    onClick: React.PropTypes.func.isRequired
+  })).isRequired
+};
+
+module.exports = ContextMenu;

--- a/content-src/components/ContextMenu/ContextMenu.scss
+++ b/content-src/components/ContextMenu/ContextMenu.scss
@@ -1,0 +1,32 @@
+.context-menu {
+  position: absolute;
+  font-size: $context-menu-font-size;
+  box-shadow: $context-menu-shadow;
+  top: 100%;
+  right: 0;
+  z-index: 10000;
+  background: $bg-grey;
+  border-radius: $context-menu-border-radius;
+
+  > ul {
+    margin: 0;
+    padding: $context-menu-outer-padding 0;
+    list-style: none;
+
+    > li {
+      > a {
+        cursor: pointer;
+        color: inherit;
+        display: block;
+        white-space: nowrap;
+        padding: $context-menu-item-padding;
+        line-height: 1;
+
+        &:hover {
+          background: $star-blue;
+          color: $white;
+        }
+      }
+    }
+  }
+}

--- a/content-src/components/DeleteMenu/DeleteMenu.js
+++ b/content-src/components/DeleteMenu/DeleteMenu.js
@@ -1,0 +1,48 @@
+const React = require("react");
+const {connect} = require("react-redux");
+const {justDispatch} = require("selectors/selectors");
+const {actions} = require("common/action-manager");
+const ContextMenu = require("components/ContextMenu/ContextMenu");
+
+const DeleteMenu = React.createClass({
+  userEvent(event) {
+    if (this.props.page && this.props.source) {
+      this.props.dispatch(actions.NotifyEvent({
+        event,
+        page: this.props.page,
+        source: this.props.source,
+        action_position: this.props.index
+      }));
+    }
+  },
+  onDelete() {
+    this.props.dispatch(actions.NotifyHistoryDelete(this.props.url));
+    this.userEvent("DELETE");
+  },
+  onBlock(url, index) {
+    this.props.dispatch(actions.BlockUrl(this.props.url));
+    this.userEvent("BLOCK");
+  },
+  render() {
+    return (<ContextMenu
+      visible={this.props.visible}
+      onUpdate={this.props.onUpdate}
+      options={[
+        {label: "Remove from History", onClick: this.onDelete},
+        {label: "Never show this page", onClick: this.onBlock}
+      ]} />);
+  }
+});
+
+DeleteMenu.propTypes = {
+  visible: React.PropTypes.bool,
+  onUpdate: React.PropTypes.func.isRequired,
+  url: React.PropTypes.string.isRequired,
+
+  // For user event tracking
+  page: React.PropTypes.string,
+  source: React.PropTypes.string,
+  index: React.PropTypes.number
+};
+
+module.exports = connect(justDispatch)(DeleteMenu);

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -38,7 +38,7 @@ const NewTabPage = React.createClass({
 
         <div className="delayedFadeIn">
           <section>
-            <TopSites sites={props.TopSites.rows} />
+            <TopSites page={PAGE_NAME} sites={props.TopSites.rows} />
           </section>
 
           <section>

--- a/content-src/components/Spotlight/Spotlight.scss
+++ b/content-src/components/Spotlight/Spotlight.scss
@@ -2,12 +2,17 @@
   font-size: 14px;
   margin-right: -$base-gutter;
 
-  ul {
+  ul.spotlight-list {
     align-items: flex-start;
     display: flex;
     list-style: none;
     margin: 0;
     padding: 0;
+  }
+
+  .context-menu {
+    top: 14px;
+    right: -12px;
   }
 }
 

--- a/content-src/components/TimelinePage/TimelineBookmarks.js
+++ b/content-src/components/TimelinePage/TimelineBookmarks.js
@@ -1,5 +1,6 @@
 const React = require("react");
 const {connect} = require("react-redux");
+const {selectBookmarks} = require("selectors/selectors");
 const GroupedActivityFeed = require("components/ActivityFeed/ActivityFeed");
 const {RequestMoreBookmarks, NotifyEvent} = require("common/action-manager").actions;
 const LoadMore = require("components/LoadMore/LoadMore");
@@ -44,10 +45,6 @@ TimelineBookmarks.propTypes = {
   Bookmarks: React.PropTypes.object.isRequired
 };
 
-module.exports = connect(state => {
-  return {
-    Bookmarks: state.Bookmarks
-  };
-})(TimelineBookmarks);
+module.exports = connect(selectBookmarks)(TimelineBookmarks);
 
 module.exports.TimelineBookmarks = TimelineBookmarks;

--- a/content-src/components/TimelinePage/TimelineHistory.js
+++ b/content-src/components/TimelinePage/TimelineHistory.js
@@ -1,6 +1,6 @@
 const React = require("react");
 const {connect} = require("react-redux");
-const {selectSpotlight} = require("selectors/selectors");
+const {selectHistory} = require("selectors/selectors");
 const {RequestMoreRecentLinks, NotifyEvent} = require("common/action-manager").actions;
 const GroupedActivityFeed = require("components/ActivityFeed/ActivityFeed");
 const Spotlight = require("components/Spotlight/Spotlight");
@@ -42,11 +42,6 @@ TimelineHistory.propTypes = {
   History: React.PropTypes.object.isRequired
 };
 
-module.exports = connect(state => {
-  return {
-    Spotlight: selectSpotlight(state),
-    History: state.History
-  };
-})(TimelineHistory);
+module.exports = connect(selectHistory)(TimelineHistory);
 
 module.exports.TimelineHistory = TimelineHistory;

--- a/content-src/components/TopSites/TopSites.scss
+++ b/content-src/components/TopSites/TopSites.scss
@@ -1,10 +1,19 @@
 .top-sites {
   .tiles-wrapper {
     margin-right: -20px;
+
     @media (min-width: $break-point) {
       display: flex;
     }
 
+    > div {
+      position: relative;
+    }
+  }
+
+  .context-menu {
+    top: 14px;
+    right: 12px;
   }
 
   .tile {

--- a/content-src/main.scss
+++ b/content-src/main.scss
@@ -66,3 +66,4 @@ a {
 @import './components/DebugPage/DebugPage';
 @import './components/Loader/Loader';
 @import './components/LoadMore/LoadMore';
+@import './components/ContextMenu/ContextMenu';

--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -88,7 +88,7 @@ module.exports.selectNewTabSites = createSelector(
     // Dedupe top activity
     const topActivityRows = dedupe.group([topSitesRows, spotlightRows, History.rows])[2].sort((a, b) => {
       return b.lastVisitDate - a.lastVisitDate;
-    });
+    }).filter(site => !Blocked.urls.has(site.url));
 
     return {
       TopSites: Object.assign({}, TopSites, {rows: topSitesRows}),
@@ -116,6 +116,34 @@ const selectSiteIcon = createSelector(
       backgroundColor,
       fontColor,
       label
+    };
+  }
+);
+
+// Timeline History view
+module.exports.selectHistory = createSelector(
+  [
+    selectSpotlight,
+    state => state.History,
+    state => state.Blocked
+  ],
+  (Spotlight, History, Blocked) => {
+    return {
+      Spotlight,
+      History: Object.assign({}, History, {rows: History.rows.filter(site => !Blocked.urls.has(site.url))})
+    };
+  }
+);
+
+// Timeline Bookmarks
+module.exports.selectBookmarks = createSelector(
+  [
+    state => state.Bookmarks,
+    state => state.Blocked
+  ],
+  (Bookmarks, Blocked) => {
+    return {
+      Bookmarks: Object.assign({}, Bookmarks, {rows: Bookmarks.rows.filter(site => !Blocked.urls.has(site.url))})
     };
   }
 );

--- a/content-src/styles/variables.scss
+++ b/content-src/styles/variables.scss
@@ -98,10 +98,17 @@ $loader-color: $search-blue;
 $loader-color-light: rgba($loader-color, 0.1);
 $loader-duration: 1.3s;
 
+$context-menu-shadow: 0 5px 10px rgba(0, 0, 0, 0.3), 0 0 0 1px rgba(0, 0, 0, 0.2);
+$context-menu-font-size: 14px;
+$context-menu-border-radius: 5px;
+$context-menu-outer-padding: 5px;
+$context-menu-item-padding: 3px 20px;
+
 @mixin item-shadow {
   box-shadow: $item-shadow;
 
-  &:hover {
+  &:hover,
+  &.active {
     box-shadow: $item-shadow-hover;
     transition: box-shadow 150ms;
   }
@@ -130,9 +137,12 @@ $loader-duration: 1.3s;
     z-index: 399;
   }
 
-  &:hover .tile-close-icon {
-    transform: scale(1);
-    opacity: 1;
-    transition-delay: 500ms;
+  &:hover,
+  &.active {
+    .tile-close-icon {
+      transform: scale(1);
+      opacity: 1;
+      transition-delay: 500ms;
+    }
   }
 }

--- a/content-test/components/ActivityFeed.test.js
+++ b/content-test/components/ActivityFeed.test.js
@@ -1,12 +1,14 @@
 const {assert} = require("chai");
 const ConnectedActivityFeed = require("components/ActivityFeed/ActivityFeed");
 const {ActivityFeedItem, GroupedActivityFeed, groupSitesBySession} = ConnectedActivityFeed;
+const DeleteMenu = require("components/DeleteMenu/DeleteMenu");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
 const {prettyUrl} = require("lib/utils");
 const moment = require("moment");
+const {renderWithProvider} = require("test/test-utils");
 
 const {faker, overrideConsoleError} = require("test/test-utils");
 const fakeSite = {
@@ -33,14 +35,14 @@ describe("ActivityFeedItem", function() {
   let instance;
   let el;
   beforeEach(() => {
-    instance = TestUtils.renderIntoDocument(<ActivityFeedItem {...fakeSite} />);
+    instance = renderWithProvider(<ActivityFeedItem {...fakeSite} />);
     el = ReactDOM.findDOMNode(instance);
   });
 
   it("should not throw if missing props", () => {
     assert.doesNotThrow(() => {
       const restore = overrideConsoleError();
-      TestUtils.renderIntoDocument(<ActivityFeedItem />);
+      renderWithProvider(<ActivityFeedItem />);
       restore();
     });
   });
@@ -72,20 +74,18 @@ describe("ActivityFeedItem", function() {
       assert.notInclude(el.className, "bookmark");
     });
     it("should have a bookmark class if the site has a bookmarkGuid", () => {
-      instance = TestUtils.renderIntoDocument(<ActivityFeedItem {...fakeSiteWithBookmark} />);
+      instance = renderWithProvider(<ActivityFeedItem {...fakeSiteWithBookmark} />);
       assert.include(ReactDOM.findDOMNode(instance).className, "bookmark");
     });
-    it("should call onDelete callback with url when delete icon is pressed", done => {
-      function onDelete(url) {
-        assert.equal(url, fakeSite.url);
-        done();
-      }
-      const item = TestUtils.renderIntoDocument(<ActivityFeedItem onDelete={onDelete} {...fakeSite} />);
+    it("should show the delete menu when the delete button is clicked", () => {
+      const item = renderWithProvider(<ActivityFeedItem {...fakeSite} />);
       const button = item.refs.delete;
       TestUtils.Simulate.click(button);
+      const deleteMenu = TestUtils.findRenderedComponentWithType(item, DeleteMenu);
+      assert.equal(deleteMenu.props.visible, true);
     });
     it("should render date if showDate=true", () => {
-      const item = TestUtils.renderIntoDocument(<ActivityFeedItem showDate={true} {...fakeSite} />);
+      const item = renderWithProvider(<ActivityFeedItem showDate={true} {...fakeSite} />);
       const lastVisitEl = item.refs.lastVisit;
       assert.equal(lastVisitEl.innerHTML, moment(fakeSite.dateDisplay).calendar());
     });
@@ -102,7 +102,7 @@ describe("GroupedActivityFeed", function() {
       faker.createSite({moment: faker.moment().subtract(2, "days")}),
       faker.createSite({moment: faker.moment().subtract(4, "days")}),
     ];
-    instance = TestUtils.renderIntoDocument(<GroupedActivityFeed sites={sites} />);
+    instance = renderWithProvider(<GroupedActivityFeed sites={sites} />);
     el = ReactDOM.findDOMNode(instance);
   });
 
@@ -117,7 +117,7 @@ describe("GroupedActivityFeed", function() {
       assert.equal(children.length, sites.length);
     });
     it("shouldn't render title if there are no sites", () => {
-      const item = TestUtils.renderIntoDocument(<GroupedActivityFeed sites={[]} title="Fake Title" />);
+      const item = renderWithProvider(<GroupedActivityFeed sites={[]} title="Fake Title" />);
       assert.isUndefined(item.refs.title);
     });
   });
@@ -139,14 +139,14 @@ describe("GroupedActivityFeed", function() {
       ];
     });
     it("should show date headings if showDateHeadings is true", () => {
-      const item = TestUtils.renderIntoDocument(<GroupedActivityFeed showDateHeadings={true} sites={sites} />);
+      const item = renderWithProvider(<GroupedActivityFeed showDateHeadings={true} sites={sites} />);
       const titles = TestUtils.scryRenderedDOMComponentsWithClass(item, "section-title");
       assert.lengthOf(titles, 2);
       assert.equal(titles[0].innerHTML, "Yesterday");
       assert.equal(titles[1].innerHTML, m3.format("[Last] dddd"));
     });
     it("should not show date headings if showDateHeadings is false", () => {
-      const item = TestUtils.renderIntoDocument(<GroupedActivityFeed showDateHeadings={false} sites={sites} />);
+      const item = renderWithProvider(<GroupedActivityFeed showDateHeadings={false} sites={sites} />);
       const titles = TestUtils.scryRenderedDOMComponentsWithClass(item, "section-title");
       assert.lengthOf(titles, 0);
     });
@@ -162,22 +162,8 @@ describe("GroupedActivityFeed", function() {
           done();
         }
       }
-      instance = TestUtils.renderIntoDocument(<GroupedActivityFeed dispatch={dispatch} page={"NEW_TAB"} sites={sites} />);
+      instance = renderWithProvider(<GroupedActivityFeed dispatch={dispatch} page={"NEW_TAB"} sites={sites} />);
       const link = TestUtils.scryRenderedComponentsWithType(instance, ActivityFeedItem)[0].refs.link;
-      TestUtils.Simulate.click(link);
-    });
-    it("should send an event onDelete", done => {
-      function dispatch(a) {
-        if (a.type === "NOTIFY_USER_EVENT") {
-          assert.equal(a.data.event, "DELETE");
-          assert.equal(a.data.page, "NEW_TAB");
-          assert.equal(a.data.source, "ACTIVITY_FEED");
-          assert.equal(a.data.action_position, 1);
-          done();
-        }
-      }
-      instance = TestUtils.renderIntoDocument(<GroupedActivityFeed dispatch={dispatch} page={"NEW_TAB"} sites={sites} />);
-      const link = TestUtils.scryRenderedComponentsWithType(instance, ActivityFeedItem)[1].refs.delete;
       TestUtils.Simulate.click(link);
     });
     it("should send an event onShare", done => {
@@ -190,7 +176,7 @@ describe("GroupedActivityFeed", function() {
           done();
         }
       }
-      instance = TestUtils.renderIntoDocument(<GroupedActivityFeed dispatch={dispatch} page={"NEW_TAB"} sites={sites} />);
+      instance = renderWithProvider(<GroupedActivityFeed dispatch={dispatch} page={"NEW_TAB"} sites={sites} />);
       const link = TestUtils.scryRenderedComponentsWithType(instance, ActivityFeedItem)[2].refs.share;
       TestUtils.Simulate.click(link);
     });

--- a/content-test/components/ContextMenu.test.js
+++ b/content-test/components/ContextMenu.test.js
@@ -1,0 +1,64 @@
+const {assert} = require("chai");
+const React = require("react");
+const ReactDOM = require("react-dom");
+const TestUtils = require("react-addons-test-utils");
+
+const ContextMenu = require("components/ContextMenu/ContextMenu");
+
+const DEFAULT_PROPS = {
+  onUpdate: () => {},
+  visible: false,
+  options: []
+};
+
+describe("ContextMenu", () => {
+  let instance;
+  let el;
+  let links;
+
+  function setup(custom = {}) {
+    const props = Object.assign({}, DEFAULT_PROPS, custom);
+    instance = TestUtils.renderIntoDocument(<ContextMenu {...props} />);
+    links = TestUtils.scryRenderedDOMComponentsWithClass(instance, "context-menu-link");
+    el = ReactDOM.findDOMNode(instance);
+  }
+
+  beforeEach(setup);
+
+  it("should render the component", () => {
+    TestUtils.isCompositeComponentWithType(instance, ContextMenu);
+  });
+  it("should be hidden by default", () => {
+    assert.equal(el.hidden, true);
+  });
+  it("should be visible if props.visible is true", () => {
+    setup({visible: true});
+    assert.equal(el.hidden, false);
+  });
+  it("should render one link per option", () => {
+    const options = [
+      {label: "Test", onClick: () => {}},
+      {label: "Test 2", onClick: () => {}},
+      {label: "Test 3", onClick: () => {}}
+    ];
+    setup({options});
+    assert.equal(links.length, options.length);
+  });
+  it("should call the onClick function when an option button is clicked", done => {
+    setup({options: [{label: "Foo", onClick() {
+      done();
+    }}]});
+    TestUtils.Simulate.click(links[0]);
+  });
+  it("should call onUpdate with false when an option is clicked", done => {
+    setup({
+      visible: true,
+      options: [{label: "Test", onClick: () => {}}],
+      onUpdate: value => {
+        assert.isFalse(value);
+        done();
+      }
+    });
+    TestUtils.Simulate.click(links[0]);
+  });
+});

--- a/content-test/components/DeleteMenu.test.js
+++ b/content-test/components/DeleteMenu.test.js
@@ -1,0 +1,111 @@
+const {assert} = require("chai");
+const React = require("react");
+const ReactDOM = require("react-dom");
+const TestUtils = require("react-addons-test-utils");
+const {renderWithProvider} = require("test/test-utils");
+const DeleteMenu = require("components/DeleteMenu/DeleteMenu");
+
+const DEFAULT_PROPS = {
+  onUpdate: () => {},
+  url: "https://foo.com",
+  visible: false
+};
+
+// In the menu, the delete option is first,
+// and the block option is second.
+const DELETE_INDEX = 0;
+const BLOCK_INDEX = 1;
+
+describe("DeleteMenu", () => {
+  let instance;
+  let el;
+  let blockLink;
+  let deleteLink;
+
+  function setup(custom = {}, customProvider = {}) {
+    const props = Object.assign({}, DEFAULT_PROPS, custom);
+    instance = renderWithProvider(<DeleteMenu {...props} />, customProvider);
+    const links = TestUtils.scryRenderedDOMComponentsWithClass(instance, "context-menu-link");
+    blockLink = links[BLOCK_INDEX];
+    deleteLink = links[DELETE_INDEX];
+    el = ReactDOM.findDOMNode(instance);
+  }
+
+  beforeEach(setup);
+
+  it("should render the component", () => {
+    TestUtils.isCompositeComponentWithType(instance, DeleteMenu);
+  });
+  it("should be hidden by default", () => {
+    assert.equal(el.hidden, true);
+  });
+  it("should be visible if props.visible is true", () => {
+    setup({visible: true});
+    assert.equal(el.hidden, false);
+  });
+  it("should have two links", () => {
+    const links = TestUtils.scryRenderedDOMComponentsWithClass(instance, "context-menu-link");
+    assert.lengthOf(links, 2);
+  });
+  it("should fire a delete event when Remove from History is clicked", done => {
+    setup(null, {
+      dispatch(a) {
+        if (a.type === "NOTIFY_HISTORY_DELETE") {
+          assert.equal(a.data, DEFAULT_PROPS.url);
+          done();
+        }
+      }
+    });
+    assert.equal(deleteLink.innerHTML, "Remove from History");
+    TestUtils.Simulate.click(deleteLink);
+  });
+  it("should fire a user event for Remove from History", done => {
+    setup({
+      page: "NEW_TAB",
+      source: "FEATURED",
+      index: 3
+    }, {
+      dispatch(a) {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.event, "DELETE");
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "FEATURED");
+          assert.equal(a.data.action_position, 3);
+          done();
+        }
+      }
+    });
+    TestUtils.Simulate.click(deleteLink);
+  });
+  it("should fire a block event when Never show this page is clicked", done => {
+    setup(null, {
+      dispatch(a) {
+        if (a.type === "BLOCK_URL") {
+          assert.equal(a.data, DEFAULT_PROPS.url);
+          done();
+        }
+      }
+    });
+    assert.equal(blockLink.innerHTML, "Never show this page");
+    TestUtils.Simulate.click(blockLink);
+  });
+  it("should fire a user event for Never show this page", done => {
+    setup({
+      page: "NEW_TAB",
+      source: "FEATURED",
+      index: 2
+    }, {
+      dispatch(a) {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.event, "BLOCK");
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "FEATURED");
+          assert.equal(a.data.action_position, 2);
+          done();
+        }
+      }
+    });
+    TestUtils.Simulate.click(blockLink);
+  });
+
+});

--- a/content-test/components/NewTabPage.test.js
+++ b/content-test/components/NewTabPage.test.js
@@ -78,4 +78,46 @@ describe("NewTabPage", () => {
     });
   });
 
+  describe("delete events", () => {
+    it("should have the correct page, source, index for top site delete menu", done => {
+      setupConnected(a => {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "TOP_SITES");
+          assert.equal(a.data.action_position, 0);
+          done();
+        }
+      });
+      const item = TestUtils.findRenderedComponentWithType(instance, TopSites);
+      const deleteLink = TestUtils.scryRenderedDOMComponentsWithClass(item, "context-menu-link")[0];
+      TestUtils.Simulate.click(deleteLink);
+    });
+    it("should have the correct page, source, index for spotlight delete menu", done => {
+      setupConnected(a => {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "FEATURED");
+          assert.equal(a.data.action_position, 0);
+          done();
+        }
+      });
+      const item = TestUtils.findRenderedComponentWithType(instance, Spotlight);
+      const deleteLink = TestUtils.scryRenderedDOMComponentsWithClass(item, "context-menu-link")[0];
+      TestUtils.Simulate.click(deleteLink);
+    });
+    it("should have the correct page, source, index for activity feed", done => {
+      setupConnected(a => {
+        if (a.type === "NOTIFY_USER_EVENT") {
+          assert.equal(a.data.page, "NEW_TAB");
+          assert.equal(a.data.source, "ACTIVITY_FEED");
+          assert.equal(a.data.action_position, 0);
+          done();
+        }
+      });
+      const item = TestUtils.findRenderedComponentWithType(instance, GroupedActivityFeed);
+      const deleteLink = TestUtils.scryRenderedDOMComponentsWithClass(item, "context-menu-link")[0];
+      TestUtils.Simulate.click(deleteLink);
+    });
+  });
+
 });

--- a/content-test/components/Spotlight.test.js
+++ b/content-test/components/Spotlight.test.js
@@ -2,12 +2,12 @@ const {assert} = require("chai");
 const moment = require("moment");
 const ConnectedSpotlight = require("components/Spotlight/Spotlight");
 const {Spotlight, SpotlightItem} = ConnectedSpotlight;
+const DeleteMenu = require("components/DeleteMenu/DeleteMenu");
 const React = require("react");
 const ReactDOM = require("react-dom");
 const TestUtils = require("react-addons-test-utils");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
-const {mockData, faker} = require("test/test-utils");
-const am = require("common/action-manager");
+const {mockData, faker, renderWithProvider} = require("test/test-utils");
 
 const fakeSpotlightItems = mockData.Spotlight.rows;
 const fakeSiteWithImage = faker.createSite();
@@ -17,7 +17,7 @@ describe("Spotlight", function() {
   let instance;
   let el;
   beforeEach(() => {
-    instance = TestUtils.renderIntoDocument(<Spotlight sites={fakeSpotlightItems} />);
+    instance = renderWithProvider(<Spotlight sites={fakeSpotlightItems} />);
     el = ReactDOM.findDOMNode(instance);
   });
 
@@ -32,20 +32,7 @@ describe("Spotlight", function() {
   });
 
   describe("actions", () => {
-    it("should fire a block action when delete button is clicked", done => {
-      let url;
-      function dispatch(a) {
-        if (a.type === am.type("BLOCK_URL")) {
-          assert.equal(a.data, url);
-          done();
-        }
-      }
-      instance = TestUtils.renderIntoDocument(<Spotlight sites={fakeSpotlightItems} dispatch={dispatch} />);
-      const firstItem = TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0];
-      url = firstItem.props.url;
-      TestUtils.Simulate.click(firstItem.refs.delete);
-    });
-    it("should fire a click event when delete is clicked", done => {
+    it("should fire a click event an item is clicked", done => {
       function dispatch(a) {
         if (a.type === "NOTIFY_USER_EVENT") {
           assert.equal(a.data.event, "CLICK");
@@ -55,37 +42,19 @@ describe("Spotlight", function() {
           done();
         }
       }
-      instance = TestUtils.renderIntoDocument(<Spotlight page={"NEW_TAB"} dispatch={dispatch} sites={fakeSpotlightItems} />);
+      instance = renderWithProvider(<Spotlight page={"NEW_TAB"} dispatch={dispatch} sites={fakeSpotlightItems} />);
       TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[0].refs.link);
-    });
-    it("should fire a delete event when delete is clicked", done => {
-      function dispatch(a) {
-        if (a.type === "NOTIFY_USER_EVENT") {
-          assert.equal(a.data.event, "DELETE");
-          assert.equal(a.data.page, "NEW_TAB");
-          assert.equal(a.data.source, "FEATURED");
-          assert.equal(a.data.action_position, 1);
-          done();
-        }
-      }
-      instance = TestUtils.renderIntoDocument(<Spotlight page={"NEW_TAB"} dispatch={dispatch} sites={fakeSpotlightItems} />);
-      TestUtils.Simulate.click(TestUtils.scryRenderedComponentsWithType(instance, SpotlightItem)[1].refs.delete);
     });
   });
 });
 
 describe("SpotlightItem", function() {
   const fakeSite = fakeSiteWithImage;
-  let node;
   let instance;
   let el;
   beforeEach(() => {
-    node = document.createElement("div");
-    instance = ReactDOM.render(<SpotlightItem {...fakeSite} />, node);
+    instance = renderWithProvider(<SpotlightItem {...fakeSite} />);
     el = ReactDOM.findDOMNode(instance);
-  });
-  afterEach(() => {
-    ReactDOM.unmountComponentAtNode(node);
   });
 
   describe("valid sites", () => {
@@ -116,24 +85,21 @@ describe("SpotlightItem", function() {
       const props = Object.assign({}, fakeSite, {
         bookmarkDateCreated: 1456426160465
       });
-      instance = TestUtils.renderIntoDocument(<SpotlightItem {...props} />);
+      instance = renderWithProvider(<SpotlightItem {...props} />);
       assert.equal(instance.refs.contextMessage.innerHTML, `Bookmarked ${moment(1456426160465).fromNow()}`);
     });
     it("should say 'Visited Recently' if no bookmark or timestamp are available", () => {
       const props = Object.assign({}, fakeSite, {
         lastVisitDate: null
       });
-      instance = TestUtils.renderIntoDocument(<SpotlightItem {...props} />);
+      instance = renderWithProvider(<SpotlightItem {...props} />);
       assert.equal(instance.refs.contextMessage.innerHTML, "Visited recently");
     });
-    it("should call onDelete callback with url when delete icon is pressed", done => {
-      function onDelete(url) {
-        assert.equal(url, fakeSite.url);
-        done();
-      }
-      const spotlight = TestUtils.renderIntoDocument(<SpotlightItem onDelete={onDelete} {...fakeSite} />);
-      const button = spotlight.refs.delete;
+    it("should show delete menu when delete icon is pressed", () => {
+      const button = instance.refs.delete;
       TestUtils.Simulate.click(button);
+      const deleteMenu = TestUtils.findRenderedComponentWithType(instance, DeleteMenu);
+      assert.equal(deleteMenu.props.visible, true);
     });
   });
 });

--- a/content-test/components/TopSites.test.js
+++ b/content-test/components/TopSites.test.js
@@ -2,12 +2,12 @@ const assert = require("chai").assert;
 const TestUtils = require("react-addons-test-utils");
 const React = require("react");
 const ReactDOM = require("react-dom");
-const {overrideConsoleError} = require("test/test-utils");
+const {overrideConsoleError, renderWithProvider} = require("test/test-utils");
 
 const ConnectedTopSites = require("components/TopSites/TopSites");
 const {TopSites} = ConnectedTopSites;
+const DeleteMenu = require("components/DeleteMenu/DeleteMenu");
 const SiteIcon = require("components/SiteIcon/SiteIcon");
-const am = require("common/action-manager");
 
 const fakeProps = {
   sites: [
@@ -23,23 +23,18 @@ const fakeProps = {
 
 describe("TopSites", () => {
 
-  let node;
   let topSites;
   let el;
 
   beforeEach(() => {
-    node = document.createElement("div");
-    topSites = ReactDOM.render(<TopSites {...fakeProps} />, node);
+    topSites = renderWithProvider(<TopSites {...fakeProps} />);
     el = ReactDOM.findDOMNode(topSites);
-  });
-  afterEach(() => {
-    ReactDOM.unmountComponentAtNode(node);
   });
 
   it("should not throw if missing props", () => {
     assert.doesNotThrow(() => {
       const restore = overrideConsoleError();
-      TestUtils.renderIntoDocument(<TopSites sites={[{}]} />);
+      renderWithProvider(<TopSites sites={[{}]} />);
       restore();
     });
   });
@@ -62,18 +57,12 @@ describe("TopSites", () => {
       assert.include(linkEls[0].href, fakeProps.sites[0].url);
       assert.include(linkEls[1].href, fakeProps.sites[1].url);
     });
-  });
 
-  describe("actions", () => {
-    it("should fire a block action when delete button is clicked", done => {
-      function dispatch(a) {
-        if (a.type === am.type("BLOCK_URL")) {
-          assert.equal(a.data, fakeProps.sites[0].url);
-          done();
-        }
-      }
-      const instance = TestUtils.renderIntoDocument(<TopSites dispatch={dispatch} sites={fakeProps.sites} />);
-      TestUtils.Simulate.click(TestUtils.scryRenderedDOMComponentsWithClass(instance, "tile-close-icon")[0]);
+    it("should show delete menu when delete button is clicked", () => {
+      const button = TestUtils.scryRenderedDOMComponentsWithClass(topSites, "tile-close-icon")[0];
+      TestUtils.Simulate.click(button);
+      const deleteMenu = TestUtils.scryRenderedComponentsWithType(topSites, DeleteMenu)[0];
+      assert.equal(deleteMenu.props.visible, true);
     });
   });
 

--- a/content-test/index.js
+++ b/content-test/index.js
@@ -5,16 +5,20 @@ const {overrideConsoleError} = require("test/test-utils");
 describe("ActivtyStreams", () => {
   let restore;
   let originalAlert;
+  let originalConfirm;
   before(() => {
     originalAlert = window.alert;
     window.alert = () => {};
     restore = overrideConsoleError(message => {
       throw new Error(message);
     });
+    originalConfirm = window.confirm;
+    window.confirm = () => true;
   });
   after(() => {
     restore();
     window.alert = originalAlert;
+    window.confirm = originalConfirm;
   });
   files.forEach(file => req(file));
   // require("test/components/NewTabPage.test.js");


### PR DESCRIPTION
This patch:

* adds a `ContextMenu` component (a little drop down with options)
* centralizes delete logic in `DeleteMenu` component that includes two options: 
     * Remove from History (this is actually deleting the item for history)
     * Never show this site (this is adding to the block list)

The delete menu has clearer language around what delete actually does, plus a confirmation alert for deleting from history. It also extends the  block list to Activity feed items as well.

Note that the block list is still in memory only, with an alert that says "we're still working on this feature"

See #483 for reference mocks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/543)
<!-- Reviewable:end -->
