### PR TITLE
fix(addon): #555 Add search to cache key

### DIFF
--- a/lib/PreviewProvider.js
+++ b/lib/PreviewProvider.js
@@ -151,7 +151,7 @@ PreviewProvider.prototype = {
   _createCacheKey(url) {
     url = new URL(url);
     let key = url.host.replace(/www\.?/, "");
-    key = key + url.pathname;
+    key = key + url.pathname + (url.search || "");
     return key.toString();
   },
 

--- a/test/test-PreviewProvider.js
+++ b/test/test-PreviewProvider.js
@@ -250,6 +250,7 @@ exports.test_dedupe_urls = function*(assert) {
   let expectedUrls = [
     {"url": "http://foo.com/", "title": "blah"},
     {"url": "http://foo.com/bar/foobar", "title": "blah"},
+    {"url": "https://www.foo.com/?q=param", "title": "blah"},
     {"url": "http://localhost-foo.com", "title": "blah"}
   ];
 


### PR DESCRIPTION
This resolves an issue where youtube links were using old cached data, since query strings weren't being included in the cache key

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/563)
<!-- Reviewable:end -->
