### PR TITLE
fix(content): #558 Dont clear rows for error append actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 ## Requirements
 
-* You must have at Firefox Beta (45.0+) installed
+* You must have at Firefox (45.0+) installed
 * node 5.0+, npm 3.0+ (You can install both [here](https://nodejs.org))
 
 ## Installation

--- a/content-src/reducers/SetRowsOrError.js
+++ b/content-src/reducers/SetRowsOrError.js
@@ -1,0 +1,42 @@
+const am = require("common/action-manager");
+
+const DEFAULTS = {
+  rows: [],
+  error: false,
+  init: false,
+  isLoading: false,
+  canLoadMore: true
+};
+
+module.exports = function setRowsOrError(requestType, responseType) {
+  return (prevState = DEFAULTS, action) => {
+    const state = {};
+    const meta = action.meta || {};
+    switch (action.type) {
+      case am.type(requestType):
+        state.isLoading = true;
+        break;
+      case am.type(responseType):
+        state.init = true;
+        state.isLoading = false;
+        if (action.error) {
+          state.rows = meta.append ? prevState.rows : [];
+          state.error = action.data;
+        } else {
+          state.rows = meta.append ? prevState.rows.concat(action.data) : action.data;
+          state.error = false;
+          if (!action.data || !action.data.length) {
+            state.canLoadMore = false;
+          }
+        }
+        break;
+      case am.type("NOTIFY_HISTORY_DELETE"):
+        state.rows = prevState.rows.filter(val => val.url !== action.data);
+        break;
+      default:
+        return prevState;
+    }
+    return Object.assign({}, prevState, state);
+  };
+};
+module.exports.DEFAULTS = DEFAULTS;

--- a/content-src/reducers/reducers.js
+++ b/content-src/reducers/reducers.js
@@ -1,45 +1,5 @@
 const am = require("common/action-manager");
-
-const DEFAULT_ROWS_OR_ERRORS_STATE = {
-  rows: [],
-  error: false,
-  init: false,
-  isLoading: false,
-  canLoadMore: true
-};
-
-function setRowsOrError(requestType, responseType) {
-  return (prevState = DEFAULT_ROWS_OR_ERRORS_STATE, action) => {
-    const state = {};
-    const meta = action.meta || {};
-    switch (action.type) {
-      case am.type(requestType):
-        state.isLoading = true;
-        break;
-      case am.type(responseType):
-        state.init = true;
-        state.isLoading = false;
-        if (action.error) {
-          state.rows = [];
-          state.error = action.data;
-        } else {
-          state.rows = meta.append ? prevState.rows.concat(action.data) : action.data;
-          state.error = false;
-          if (!action.data.length) {
-            state.canLoadMore = false;
-          }
-        }
-        break;
-      case "NOTIFY_HISTORY_DELETE":
-        state.rows = prevState.rows.filter(val => val.url !== action.data);
-        break;
-      // TODO: Handle changes
-      default:
-        return prevState;
-    }
-    return Object.assign({}, prevState, state);
-  };
-}
+const setRowsOrError = require("reducers/SetRowsOrError");
 
 function setSearchState(type) {
   return (prevState = {currentEngine: {}, error: false, init: false}, action) => {

--- a/content-test/reducers/SetRowsOrError.test.js
+++ b/content-test/reducers/SetRowsOrError.test.js
@@ -1,0 +1,81 @@
+const {assert} = require("chai");
+const setRowsOrError = require("reducers/SetRowsOrError");
+const REQUEST_TYPE = "RECENT_LINKS_REQUEST";
+const RESPONSE_TYPE = "RECENT_LINKS_RESPONSE";
+
+describe("setRowsOrError", () => {
+  let reducer;
+  beforeEach(() => {
+    reducer = setRowsOrError(REQUEST_TYPE, RESPONSE_TYPE);
+  });
+
+  it("should return a function", () => {
+    assert.isFunction(reducer);
+  });
+
+  it("should leave the state unchanged for unrelated events", () => {
+    const action = {type: "OTHER_REQUEST"};
+    assert.deepEqual(reducer(undefined, action), setRowsOrError.DEFAULTS);
+  });
+
+  it("should set the loading state to true if a request is received", () => {
+    const action = {type: REQUEST_TYPE};
+    const state = reducer(undefined, action);
+    assert.isTrue(state.isLoading);
+  });
+
+  it("should set init to true / loading to false when a response is received", () => {
+    const action = {type: RESPONSE_TYPE};
+    const state = reducer(undefined, action);
+    assert.isTrue(state.init);
+    assert.isFalse(state.isLoading);
+  });
+
+  it("should set init to true / loading to false when a response with error is received", () => {
+    const action = {type: RESPONSE_TYPE, error: true};
+    const state = reducer(undefined, action);
+    assert.isTrue(state.init);
+    assert.isFalse(state.isLoading);
+  });
+
+  it("should set rows", () => {
+    const rows = [{url: "a"}, {url: "b"}];
+    const action = {type: RESPONSE_TYPE, data: rows};
+    const state = reducer(undefined, action);
+    assert.deepEqual(state.rows, rows);
+  });
+
+  it("should append rows for append type action", () => {
+    const prevRows = [{url: "x"}, {url: "y"}];
+    const newRows = [{url: "a"}, {url: "b"}];
+    const action = {type: RESPONSE_TYPE, data: newRows, meta: {append: true}};
+    const state = reducer(Object.assign({}, setRowsOrError.DEFAULTS, {rows: prevRows}), action);
+    assert.deepEqual(state.rows, prevRows.concat(newRows));
+  });
+
+  it("should set an error if the action contains an error ", () => {
+    const action = {type: RESPONSE_TYPE, error: true, data: new Error("Test")};
+    const state = reducer(undefined, action);
+    assert.deepEqual(state.error, action.data);
+  });
+
+  it("should set rows to empty for non-append error actions", () => {
+    const action = {type: RESPONSE_TYPE, error: true, data: new Error("Test")};
+    const state = reducer(undefined, action);
+    assert.deepEqual(state.rows, []);
+  });
+
+  it("should leave rows unchanged for append-type error actions", () => {
+    const action = {type: RESPONSE_TYPE, error: true, meta: {append: true}, data: new Error("Test")};
+    const prevRows = [{url: "a"}, {url: "b"}];
+    const state = reducer(Object.assign({}, setRowsOrError.DEFAULTS, {rows: prevRows}), action);
+    assert.deepEqual(state.rows, prevRows);
+  });
+
+  it("should remove rows that are deleted", () => {
+    const action = {type: "NOTIFY_HISTORY_DELETE", data: "http://foo.com"};
+    const prevRows = [{url: "http://foo.com"}, {url: "http://bar.com"}];
+    const state = reducer(Object.assign({}, setRowsOrError.DEFAULTS, {rows: prevRows}), action);
+    assert.deepEqual(state.rows, [{url: "http://bar.com"}]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -146,7 +146,7 @@
     "test:jpm": "jpm test -b ${JPM_FIREFOX_BINARY:-\"firefox\"} --prefs ./test-prefs.json",
     "test:karma": "NODE_ENV=test karma start",
     "posttest": "cat logs/reports/coverage/text-summary.txt",
-    "tdd": "NODE_ENV=test npm run copyTestImages && karma start --no-single-run --browsers Chrome",
+    "tdd": "npm run test:karma -- --no-single-run --browsers Chrome",
     "package": "npm run bundle && jpm xpi && mv @activity-streams-$npm_package_version.xpi dist/activity-streams-$npm_package_version.xpi",
     "travis": "npm run test",
     "precommit": "npm run test:lint && npm run yamscripts",

--- a/yamscripts.yml
+++ b/yamscripts.yml
@@ -49,7 +49,7 @@ scripts:
     post: cat logs/reports/coverage/text-summary.txt
 
 # tdd: Run content tests continuously
-  tdd: NODE_ENV=test =>copyTestImages && karma start --no-single-run --browsers Chrome
+  tdd: =>test:karma -- --no-single-run --browsers Chrome
 
 # package: Build add-on
   package: =>bundle && jpm xpi && mv @activity-streams-$npm_package_version.xpi dist/activity-streams-$npm_package_version.xpi


### PR DESCRIPTION
Right now, if an append-type response with an error is received (e.g. a timeout), we actually clear the whole rows value, which isn't what we want.

This PR changes the behaviour to leave `rows` unchanged for append-type errors.

We also might want to adjust the timeout maybe?

Fixes #558 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/576)
<!-- Reviewable:end -->
