### PR TITLE
feat(reporting): #477 End session on route change

### DIFF
--- a/content-src/components/Routes/Routes.js
+++ b/content-src/components/Routes/Routes.js
@@ -5,11 +5,15 @@ const {connect} = require("react-redux");
 const {actions} = require("common/action-manager");
 
 const history = createHashHistory({queryKey: false});
+let isFirstLoad = true;
 
 const Routes = React.createClass({
   componentDidMount() {
     this.unlisten = history.listen(location => {
-      this.props.dispatch(actions.NotifyRouteChange(location));
+      this.props.dispatch(actions.NotifyRouteChange(Object.assign({}, location, {isFirstLoad})));
+      if (isFirstLoad) {
+        isFirstLoad = false;
+      }
       window.scroll(0, 0);
     });
   },

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -200,7 +200,10 @@ ActivityStreams.prototype = {
     this._tabTracker.handleUserEvent(data.msg.data);
   },
 
-  _onRouteChange() {
+  _onRouteChange(eventName, data) {
+    if (data) {
+      this._tabTracker.handleRouteChange(tabs.activeTab, data.msg.data);
+    }
     this._appURLHider.maybeHideURL(tabs.activeTab);
   },
 

--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -49,7 +49,7 @@ TabTracker.prototype = {
       tab.removeListener("ready", this.logReady);
       tab.removeListener("activate", this.logActivate);
       tab.removeListener("deactivate", this.logDeactivate);
-      tab.removeListener("close", this.logDeactivate);
+      tab.removeListener("close", this.logClose);
     }
     tabs.removeListener("open", this.onOpen);
 
@@ -101,6 +101,13 @@ TabTracker.prototype = {
     payload.tab_id = tabs.activeTab.id;
     this._setCommonProperties(payload, tabs.activeTab.url);
     Services.obs.notifyObservers(null, ACTION_NOTIF, JSON.stringify(payload));
+  },
+
+  handleRouteChange(tab, route) {
+    if (!route.isFirstLoad) {
+      this.navigateAwayFromPage(tab, "route_change");
+      this.logReady(tab);
+    }
   },
 
   navigateAwayFromPage(tab, reason) {
@@ -171,22 +178,23 @@ TabTracker.prototype = {
     }
   },
 
-  logDeactivate(reason) {
-    return tab => {
-      if (this.isActivityStreamsURL(tab.url)) {
-        this.navigateAwayFromPage(tab, reason);
-      }
-    };
+  logDeactivate(tab) {
+    // If there is no activeTab, that means we closed the whole window
+    // we already log "close", so no need to log deactivate as well.
+    if (!tabs.activeTab) {
+      return;
+    }
+    if (this.isActivityStreamsURL(tab.url)) {
+      this.navigateAwayFromPage(tab, "unfocus");
+    }
   },
 
-  logClose(reason) {
-    return tab => {
-      if (tabs.activeTab && tabs.activeTab.id === tab.id) {
-        this.logDeactivate(reason)(tab);
-      }
-      // get rid of that tab reference
-      delete this._openTabs[tab.id];
-    };
+  logClose(tab) {
+    if (this.isActivityStreamsURL(tab.url)) {
+      this.navigateAwayFromPage(tab, "close");
+    }
+    // get rid of that tab reference
+    delete this._openTabs[tab.id];
   },
 
   onOpen(tab) {
@@ -195,11 +203,12 @@ TabTracker.prototype = {
     this.logReady = this.logReady.bind(this);
     this.logActivate = this.logActivate.bind(this);
     this.logDeactivate = this.logDeactivate.bind(this);
+    this.logClose = this.logClose.bind(this);
 
     tab.on("ready", this.logReady);
     tab.on("activate", this.logActivate);
-    tab.on("deactivate", this.logDeactivate("unfocus"));
-    tab.on("close", this.logClose("close"));
+    tab.on("deactivate", this.logDeactivate);
+    tab.on("close", this.logClose);
 
     // update history and bookmark sizes
     this._placesQueries.getHistorySize().then(size => {this._tabData.historySize = size;});


### PR DESCRIPTION
This patch: 

* ends a session with a new `unload_reason` of `route_change`
* changes a session end caused by a window closing to use `close`, not `unfocus`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/596)
<!-- Reviewable:end -->
