### PR TITLE
fix(content): #572 pre-dedupe TopSites

### DIFF
--- a/content-src/selectors/selectors.js
+++ b/content-src/selectors/selectors.js
@@ -73,18 +73,18 @@ const selectSpotlight = module.exports.selectSpotlight = createSelector(
   }
 );
 
-const selectTopSites = createSelector(
+const selectTopSites = module.exports.selectTopSites = createSelector(
   [
     state => state.TopSites,
     state => state.Blocked
   ],
   (TopSites, Blocked) => {
     return Object.assign({}, TopSites, {
-      rows: TopSites.rows
+      rows: dedupe.one(TopSites.rows
         // Removed blocked URLs
         .filter(site => !Blocked.urls.has(site.url))
         // Add first run stuff to the end if init has already happened
-        .concat(TopSites.init ? firstRunData.TopSites : [])
+        .concat(TopSites.init ? firstRunData.TopSites : []))
     });
   }
 );

--- a/content-test/selectors/selectors.test.js
+++ b/content-test/selectors/selectors.test.js
@@ -7,6 +7,7 @@ const firstRunData = require("lib/first-run-data");
 const {
   justDispatch,
   selectSpotlight,
+  selectTopSites,
   selectNewTabSites,
   selectSiteIcon,
   getBackgroundRGB,
@@ -162,6 +163,42 @@ describe("selectors", () => {
         Blocked: {urls: new Set([frecent[0].url])}
       });
       assert.equal(state.rows.length, firstRunData.Highlights.length + frecent.length - 1);
+    });
+  });
+  describe("selectTopSites", () => {
+    it("should add default sites if init is true", () => {
+      const rows = [{url: "http://foo.com"}, {url: "http://bar.com"}];
+      const result = selectTopSites({
+        TopSites: {init: true, rows},
+        Blocked: {urls: new Set()}
+      });
+      assert.isTrue(result.init);
+      assert.deepEqual(result.rows, rows.concat(firstRunData.TopSites));
+    });
+    it("should not add default sites if init is false", () => {
+      const rows = [{url: "http://foo.com"}, {url: "http://bar.com"}];
+      const result = selectTopSites({
+        TopSites: {init: false, rows},
+        Blocked: {urls: new Set()}
+      });
+      assert.isFalse(result.init);
+      assert.deepEqual(result.rows, rows);
+    });
+    it("should dedupe by url", () => {
+      const rows = [{url: "http://foo.com"}, {url: "http://www.foo.com"}];
+      const result = selectTopSites({
+        TopSites: {init: false, rows},
+        Blocked: {urls: new Set()}
+      });
+      assert.deepEqual(result.rows, [{url: "http://foo.com"}]);
+    });
+    it("should remove items in the block list", () => {
+      const rows = [{url: "http://foo.com"}, {url: "http://bar.com"}];
+      const result = selectTopSites({
+        TopSites: {init: false, rows},
+        Blocked: {urls: new Set(["http://bar.com"])}
+      });
+      assert.deepEqual(result.rows, [{url: "http://foo.com"}]);
     });
   });
   describe("selectNewTabSites", () => {


### PR DESCRIPTION
This will prevent there being missing top sites if any deduping happens internally within Top Sites

Fixes #572 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/614)
<!-- Reviewable:end -->
