### PR TITLE
fix(addon): #625 Renaming ping attributes for bookmarks and history counts

### DIFF
--- a/data_events.md
+++ b/data_events.md
@@ -130,8 +130,8 @@ All `"activity_stream_session"` pings have the following basic shape. Some field
   "load_reason": "[newtab | focus]",
   "unload_reason": "[navigation | unfocus | refresh]",
 
-  "historySize": 446,
-  "bookmarkSize": 57,
+  "total_history_size": 446,
+  "total_bookmarks": 57,
   "tab_id": "-5-2",
   "load_latency": 774,
   "client_id": "26288a14-5cc4-d14f-ae0a-bb01ef45be9c",

--- a/lib/TabTracker.js
+++ b/lib/TabTracker.js
@@ -60,10 +60,10 @@ TabTracker.prototype = {
 
   _clearTabData() {
     // keep history and bookmarks sizes of the current tabData
-    let {historySize, bookmarkSize} = this._tabData;
+    let {total_history_size, total_bookmarks} = this._tabData;
     this._tabData = {
-      historySize: historySize,
-      bookmarkSize: bookmarkSize,
+      total_history_size,
+      total_bookmarks
     };
   },
 
@@ -211,8 +211,8 @@ TabTracker.prototype = {
     tab.on("close", this.logClose);
 
     // update history and bookmark sizes
-    this._placesQueries.getHistorySize().then(size => {this._tabData.historySize = size;});
-    this._placesQueries.getBookmarksSize().then(size => {this._tabData.bookmarkSize = size;});
+    this._placesQueries.getHistorySize().then(size => {this._tabData.total_history_size = size;});
+    this._placesQueries.getBookmarksSize().then(size => {this._tabData.total_bookmarks = size;});
   },
 
   _onPrefChange() {

--- a/test/test-TabTracker.js
+++ b/test/test-TabTracker.js
@@ -13,7 +13,7 @@ Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/ClientID.jsm");
 
 const EXPECTED_KEYS = ["url", "tab_id", "session_duration", "client_id", "unload_reason", "addon_version",
-                       "page", "load_reason", "locale", "historySize", "bookmarkSize", "action"];
+                       "page", "load_reason", "locale", "total_history_size", "total_bookmarks", "action"];
 
 let ACTIVITY_STREAMS_URL;
 let app;
@@ -312,8 +312,8 @@ exports.test_TabTracker_History_And_Bookmark_Reporting = function*(assert) {
   tabs.open(ACTIVITY_STREAMS_URL);
   let pingData = yield waitForPageLoadAndSessionComplete();
   checkLoadUnloadReasons(assert, [pingData], ["newtab"], ["close"], true);
-  assert.equal(pingData.historySize, 0, "Nothing in history");
-  assert.equal(pingData.bookmarkSize, 0, "Nothing in bookmarks");
+  assert.equal(pingData.total_history_size, 0, "Nothing in history");
+  assert.equal(pingData.total_bookmarks, 0, "Nothing in bookmarks");
 
   // add visits and bookmark them
   yield PlacesTestUtils.insertAndBookmarkVisit("https://mozilla1.com/0");
@@ -331,8 +331,8 @@ exports.test_TabTracker_History_And_Bookmark_Reporting = function*(assert) {
 
   tabs.open(ACTIVITY_STREAMS_URL);
   pingData = yield waitForPageLoadAndSessionComplete();
-  assert.equal(pingData.historySize, 2, "2 new visits history");
-  assert.equal(pingData.bookmarkSize, 2, "2 new bookmarks");
+  assert.equal(pingData.total_history_size, 2, "2 new visits history");
+  assert.equal(pingData.total_bookmarks, 2, "2 new bookmarks");
 
   PlacesTestUtils.clearBookmarks();
   yield PlacesTestUtils.clearHistory();


### PR DESCRIPTION
Fixes #625 

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/636)
<!-- Reviewable:end -->
