### PR TITLE
fix(concurrency): guard against handlers called when ActivityStream object is gone

### DIFF
--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -185,7 +185,7 @@ ActivityStreams.prototype = {
   _handlePlacesChanges(eventName, data) {
     /* note: this will execute for each of the 3 notifications that occur
      * when adding a visit: frecency:-1, frecency: real frecency, title */
-    if (!this._populatingCache.places) {
+    if (this._populatingCache && !this._populatingCache.places) {
       this._asyncBuildPlacesCache();
     }
 
@@ -296,7 +296,7 @@ ActivityStreams.prototype = {
    */
   _asyncBuildPlacesCache: Task.async(function*() {
     if (simplePrefs.prefs["query.cache"]) {
-      if (!this._populatingCache.places) {
+      if (this._populatingCache && !this._populatingCache.places) {
         this._populatingCache.places = true;
         let opt = {replace: true};
         yield Promise.all([
@@ -317,7 +317,7 @@ ActivityStreams.prototype = {
    * Builds a preview cache with links from a normal content page load
    */
   _asyncBuildPreviewCache: Task.async(function*() {
-    if (!this._populatingCache.preview) {
+    if (this._populatingCache && !this._populatingCache.preview) {
       this._populatingCache.preview = true;
       let linksToSend = [];
       let promises = [];
@@ -477,8 +477,10 @@ ActivityStreams.prototype = {
       this._appURLHider.uninit();
       this._perfMeter.uninit();
       this._memoizer.uninit();
-      this._populatingCache.places = false;
-      this._populatingCache.preview = false;
+      this._populatingCache = {
+        places: false,
+        preview: false,
+      };
     };
 
     switch (reason){


### PR DESCRIPTION
r? @k88hudson

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/660)
<!-- Reviewable:end -->
