### PR TITLE
Loading improvements

### DIFF
--- a/content-src/components/Loader/Loader.js
+++ b/content-src/components/Loader/Loader.js
@@ -1,20 +1,25 @@
 const React = require("react");
+const classNames = require("classnames");
 
 const Loader = React.createClass({
   getDefaultProps() {
     return {
-      show: false
+      show: false,
+      label: "Loading..."
     };
   },
   render() {
-    return (<div className="loader" hidden={!this.props.show}>
-      <div className="spinner"/> Loading...
+    return (<div className={classNames("loader", this.props.className, {centered: this.props.centered})} hidden={!this.props.show}>
+      <div className="spinner"/> {this.props.label}
     </div>);
   }
 });
 
 Loader.propTypes = {
-  show: React.PropTypes.bool
+  show: React.PropTypes.bool,
+  label: React.PropTypes.string,
+  className: React.PropTypes.string,
+  centered: React.PropTypes.bool
 };
 
 module.exports = Loader;

--- a/content-src/components/Loader/Loader.scss
+++ b/content-src/components/Loader/Loader.scss
@@ -4,6 +4,10 @@
   align-items: center;
   font-size: 13px;
 
+  &.centered {
+    justify-content: center;
+  }
+
   .spinner {
     flex-shrink: 0;
     margin-right: 10px;

--- a/content-src/components/NewTabPage/NewTabPage.js
+++ b/content-src/components/NewTabPage/NewTabPage.js
@@ -5,6 +5,7 @@ const TopSites = require("components/TopSites/TopSites");
 const GroupedActivityFeed = require("components/ActivityFeed/ActivityFeed");
 const Spotlight = require("components/Spotlight/Spotlight");
 const Search = require("components/Search/Search");
+const Loader = require("components/Loader/Loader");
 const ContextMenu = require("components/ContextMenu/ContextMenu");
 const {actions} = require("common/action-manager");
 const {Link} = require("react-router");
@@ -49,6 +50,13 @@ const NewTabPage = React.createClass({
         <section>
           <Search onSearch={this.onSearch} />
         </section>
+
+        <Loader
+          className="loading-notice"
+          show={!this.props.isReady}
+          label="Hang on tight! We are analyzing your history to personalize your experience"
+          centered
+        />
 
         <div className={classNames("show-on-init", {on: this.props.isReady})}>
           <section>

--- a/content-src/components/NewTabPage/NewTabPage.scss
+++ b/content-src/components/NewTabPage/NewTabPage.scss
@@ -4,6 +4,23 @@
   margin: 0 auto;
 }
 
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+  }
+
+  to {
+    opacity: 1;
+  }
+}
+
+.loading-notice {
+  animation-name: fadeIn;
+  animation-duration: 1s;
+  animation-delay: 2s;
+  animation-fill-mode: both;
+}
+
 .bottom-links-container {
   text-align: left;
 

--- a/content-src/lib/ReduxChannel.js
+++ b/content-src/lib/ReduxChannel.js
@@ -1,5 +1,5 @@
 const DEFAULT_OPTIONS = {
-  timeout: 5000,
+  timeout: 20000,
   target: window
 };
 

--- a/content-src/reducers/SetRowsOrError.js
+++ b/content-src/reducers/SetRowsOrError.js
@@ -17,12 +17,12 @@ module.exports = function setRowsOrError(requestType, responseType) {
         state.isLoading = true;
         break;
       case am.type(responseType):
-        state.init = true;
         state.isLoading = false;
         if (action.error) {
           state.rows = meta.append ? prevState.rows : [];
           state.error = action.data;
         } else {
+          state.init = true;
           state.rows = meta.append ? prevState.rows.concat(action.data) : action.data;
           state.error = false;
           if (!action.data || !action.data.length) {

--- a/content-test/components/Loader.test.js
+++ b/content-test/components/Loader.test.js
@@ -24,4 +24,16 @@ describe("Loader", () => {
     setup({show: true});
     assert.isFalse(el.hidden);
   });
+  it("should render a custom label", () => {
+    setup({label: "Hello world"});
+    assert.equal(el.textContent, " Hello world");
+  });
+  it("should add className to the default className", () => {
+    setup({className: "foo"});
+    assert.equal(el.className, "loader foo");
+  });
+  it("should add 'centered' class for centered prop", () => {
+    setup({centered: true});
+    assert.equal(el.className, "loader centered");
+  });
 });

--- a/content-test/reducers/SetRowsOrError.test.js
+++ b/content-test/reducers/SetRowsOrError.test.js
@@ -24,17 +24,17 @@ describe("setRowsOrError", () => {
     assert.isTrue(state.isLoading);
   });
 
-  it("should set init to true / loading to false when a response is received", () => {
+  it("should set init to true/loading to false when a response is received", () => {
     const action = {type: RESPONSE_TYPE};
     const state = reducer(undefined, action);
     assert.isTrue(state.init);
     assert.isFalse(state.isLoading);
   });
 
-  it("should set init to true / loading to false when a response with error is received", () => {
+  it("should not set init to true and loading to false when a response with error is received", () => {
     const action = {type: RESPONSE_TYPE, error: true};
     const state = reducer(undefined, action);
-    assert.isTrue(state.init);
+    assert.isFalse(state.init);
     assert.isFalse(state.isLoading);
   });
 

--- a/lib/ActivityStreams.js
+++ b/lib/ActivityStreams.js
@@ -111,7 +111,7 @@ ActivityStreams.prototype = {
     switch (msgName) {
       case am.type("TOP_FRECENT_SITES_REQUEST"):
         this._memoized.getTopFrecentSites(msg.data).then(links => {
-          this._processAndSendLinks(links, "TOP_FRECENT_SITES_RESPONSE", append, worker, true);
+          this._processAndSendLinks(links, "TOP_FRECENT_SITES_RESPONSE", append, worker);
         });
         break;
       case am.type("RECENT_BOOKMARKS_REQUEST"):
@@ -126,7 +126,7 @@ ActivityStreams.prototype = {
         break;
       case am.type("HIGHLIGHTS_LINKS_REQUEST"):
         this._memoized.getHighlightsLinks(msg.data).then(links => {
-          this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", append, worker, true);
+          this._processAndSendLinks(links, "HIGHLIGHTS_LINKS_RESPONSE", append, worker);
         });
         break;
       case am.type("NOTIFY_HISTORY_DELETE"):


### PR DESCRIPTION
This patch:

* removes the `previewsOnly` constraint for Highlights/TopSites
* increases the timeout content-side from `5s` to `20s`
* shows a loading spinner that says `Hang on tight! We are analyzing your history to personalize your experience` if loading is taking longer than 20 seconds

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/662)
<!-- Reviewable:end -->
