### PR TITLE
chore(travis): Lock to 46.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ cache:
     - node_modules
 
 addons:
-  firefox: "latest-beta"
+  firefox: "46.0"
 
 before_install:
   # see https://docs.travis-ci.com/user/gui-and-headless-browsers/#Using-xvfb-to-Run-Tests-That-Require-a-GUI
@@ -35,11 +35,11 @@ script:
   - npm run travis
 
 deploy:
-    skip_cleanup: true
-    provider: script
-    script: bin/continuous-integration.sh
-    on:
-        branch: master
+  skip_cleanup: true
+  provider: script
+  script: bin/continuous-integration.sh
+  on:
+      branch: master
 
 notifications:
   email: false

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "istanbul-instrumenter-loader": "0.1.3",
     "jpm": "1.0.5",
     "jscs": "2.9.0",
+    "json-loader": "0.5.4",
     "karma": "0.13.19",
     "karma-chrome-launcher": "0.2.2",
     "karma-coverage": "0.5.3",


### PR DESCRIPTION
It seems like for some reason after `47.0b3`, travis hangs on creating a profile – I'm not sure why. I also noticed we removed `json-loader` by accident (it's needed for webpack to load json).

Anyway, creating a profile seems to be fine on `46.0`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mozilla/activity-streams/664)
<!-- Reviewable:end -->
